### PR TITLE
Fixed TP supports and added TP supports along w/ autosolvers

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -99,6 +99,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["gatekeeper"] = module => new GatekeeperComponentSolver(module);
 		ModComponentSolverCreators["stateOfAggregation"] = module => new StateOfAggregationComponentSolver(module);
 		ModComponentSolverCreators["conditionalButtons"] = module => new ConditionalButtonsComponentSolver(module);
+		ModComponentSolverCreators["buttonOrder"] = module => new ButtonOrderComponentSolver(module);
+		ModComponentSolverCreators["strikeSolve"] = module => new StrikeSolveComponentSolver(module);
 		// Misc [ZekNikZ]
 		ModComponentSolverCreators["EdgeworkModule"] = module => new EdgeworkComponentSolver(module);
 		ModComponentSolverCreators["LEGOModule"] = module => new LEGOComponentSolver(module);
@@ -264,6 +266,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["gatekeeper"] = new ModuleInformation { builtIntoTwitchPlays = true };
 		ModComponentSolverInformation["stateOfAggregation"] = new ModuleInformation { builtIntoTwitchPlays = true };
 		ModComponentSolverInformation["conditionalButtons"] = new ModuleInformation { builtIntoTwitchPlays = true };
+		ModComponentSolverInformation["buttonOrder"] = new ModuleInformation { builtIntoTwitchPlays = true };
+		ModComponentSolverInformation["strikeSolve"] = new ModuleInformation { builtIntoTwitchPlays = true };
 
 		//Steel Crate Games (Need these in place even for the Vanilla modules)
 		ModComponentSolverInformation["WireSetComponentSolver"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Wires", scoreString = "1" };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/AlphaComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/AlphaComponentSolver.cs
@@ -9,7 +9,7 @@ public class AlphaComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("submit")) yield break;
+		if (split.Length != 2 || !command.StartsWith("submit ")) yield break;
 		if (!int.TryParse(split[1], out _)) yield break;
 		if (int.Parse(split[1]) < 0 || int.Parse(split[1]) > 20) yield break;
 		if (!_component.GetValue<bool>("active"))

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/HyperactiveNumsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/HyperactiveNumsComponentSolver.cs
@@ -11,7 +11,7 @@ public class HyperactiveNumsComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 3 || !command.StartsWith("submit")) yield break;
+		if (split.Length != 3 || !command.StartsWith("submit ")) yield break;
 		if (!_colors.Contains(split[1])) yield break;
 		if (!split[2].EqualsAny("even", "odd")) yield break;
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/MorseIdentificationComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/MorseIdentificationComponentSolver.cs
@@ -10,7 +10,7 @@ public class MorseIdentificationComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("submit")) yield break;
+		if (split.Length != 2 || !command.StartsWith("submit ")) yield break;
 		if (!split[1].RegexMatch("^[a-z0-9]$")) yield break;
 		if (!_component.GetValue<bool>("needyactive"))
 		{

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/ReflexComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/LeGeND/ReflexComponentSolver.cs
@@ -10,7 +10,7 @@ public class ReflexComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("press")) yield break;
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
 		if (!int.TryParse(split[1], out _)) yield break;
 		if (int.Parse(split[1]) < 1 || int.Parse(split[1]) > 7) yield break;
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ButtonOrderComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ButtonOrderComponentSolver.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+
+public class ButtonOrderComponentSolver : ReflectionComponentSolver
+{
+	public ButtonOrderComponentSolver(TwitchModule module) :
+		base(module, "SylwiaScript", "!{0} press <btn1> <btn2> [Presses the specified buttons in order] | Valid buttons are 1 and 2")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length != 3 || !command.StartsWith("press ")) yield break;
+		if (!command.Substring(6).EqualsAny("1 2", "2 1")) yield break;
+
+		yield return null;
+		yield return Click(int.Parse(split[1]) - 1);
+		yield return Click(int.Parse(split[2]) - 1, 0);
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		int order = _component.GetValue<int>("order");
+		int press = _component.GetValue<int>("press");
+		if (press == 0)
+			yield return Click(order - 1);
+		else if ((press == 1 && order == 2) || (press == 2 && order == 1))
+			yield break;
+		yield return Click((order - 1) == 0 ? 1 : 0);
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/CaesarsMathsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/CaesarsMathsComponentSolver.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System;
 using UnityEngine;
 
 public class CaesarsMathsComponentSolver : ReflectionComponentSolver
@@ -11,7 +10,7 @@ public class CaesarsMathsComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("press")) yield break;
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
 		if (!split[1].EqualsAny("left", "l", "middle", "m", "right", "r")) yield break;
 
 		yield return null;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ConditionalButtonsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ConditionalButtonsComponentSolver.cs
@@ -11,7 +11,7 @@ public class ConditionalButtonsComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length < 2 || !command.StartsWith("press")) yield break;
+		if (split.Length < 2 || !command.StartsWith("press ")) yield break;
 		for (int i = 1; i < split.Length; i++)
 		{
 			if (!split[i].EqualsAny("tl", "tm", "tr", "bl", "bm", "br", "1", "2", "3", "4", "5", "6")) yield break;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/GatekeeperComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/GatekeeperComponentSolver.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System;
 
 public class GatekeeperComponentSolver : ReflectionComponentSolver
 {
@@ -10,7 +9,7 @@ public class GatekeeperComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("press")) yield break;
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
 		if (!split[1].EqualsAny("left", "l", "middle", "m", "right", "r")) yield break;
 
 		yield return null;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StateOfAggregationComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StateOfAggregationComponentSolver.cs
@@ -12,8 +12,8 @@ public class StateOfAggregationComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (!command.Equals("cycle temp") && !command.StartsWith("submit")) yield break;
-		if (command.StartsWith("submit"))
+		if (!command.Equals("cycle temp") && !command.StartsWith("submit ")) yield break;
+		if (command.StartsWith("submit "))
 		{
 			if (split.Length < 3) yield break;
 			string[] groups = new string[_component.GetValue<string[]>("groups").Length];

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StrikeSolveComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StrikeSolveComponentSolver.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections;
+
+public class StrikeSolveComponentSolver : ReflectionComponentSolver
+{
+	public StrikeSolveComponentSolver(TwitchModule module) :
+		base(module, "strikeSolveScript", "!{0} press <strike/solve> [Presses the strike or solve button]")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
+		if (!split[1].EqualsAny("strike", "solve")) yield break;
+
+		yield return null;
+		string[] btns = new string[] { "solve", "strike" };
+		yield return Click(Array.IndexOf(btns, split[1]), 0);
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		string[] btns = new string[] { "solve", "strike" };
+		string correctButton = _component.GetValue<string>("buttonToPress");
+		yield return Click(correctButton == "any" ? UnityEngine.Random.Range(0, 2) : Array.IndexOf(btns, correctButton));
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/ForeignExchangeRatesComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/ForeignExchangeRatesComponentSolver.cs
@@ -10,6 +10,7 @@ public class ForeignExchangeRatesComponentSolver : ComponentSolver
 	public ForeignExchangeRatesComponentSolver(TwitchModule module) :
 		base(module)
 	{
+		_component = module.BombComponent.GetComponent(ComponentType);
 		_buttons = (MonoBehaviour[]) ButtonsField.GetValue(module.BombComponent.GetComponent(ComponentType));
 		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Solve the module with !{0} press ML. Positions are TL, TM, TR, ML, MM, MR, BL, BM, BR.");
 	}
@@ -56,8 +57,21 @@ public class ForeignExchangeRatesComponentSolver : ComponentSolver
 		yield return DoInteractionClick(button);
 	}
 
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		while (!_component.GetValue<bool>("isReadyForInput")) yield return true;
+		int answer = _component.GetValue<int>("answer");
+		if (answer == 0)
+			yield return DoInteractionClick(_buttons[0]);
+		else
+			yield return DoInteractionClick(_buttons[answer - 1]);
+	}
+
 	private static readonly Type ComponentType = ReflectionHelper.FindType("ForeignExchangeRates");
 	private static readonly FieldInfo ButtonsField = ComponentType.GetField("buttons", BindingFlags.Public | BindingFlags.Instance);
+
+	private readonly object _component;
 
 	private readonly MonoBehaviour[] _buttons;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/MemorableButtonsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/MemorableButtonsComponentSolver.cs
@@ -66,6 +66,40 @@ public class MemorableButtonsComponentSolver : ComponentSolver
 		}
 	}
 
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		while (_component.GetValue<int>("iterationsRemaining") > 0)
+		{
+			TextMesh[] labels = _component.GetValue<TextMesh[]>("buttonLabels");
+			string correct = _component.GetValue<string>("correctLabel");
+			for (int i = 0; i < 4; i++)
+			{
+				if (labels[i].text == correct)
+				{
+					yield return DoInteractionClick(interKeypad[i]);
+					break;
+				}
+			}
+		}
+		string code = _component.GetValue<string>("combinedCode");
+		int start = _component.GetValue<int>("solveStage");
+		int end = _component.GetValue<int>("totalStages");
+		for (int i = start; i < end; i++)
+		{
+			TextMesh[] solveLabels = _component.GetValue<TextMesh[]>("solveButtonLabels");
+			for (int j = 0; j < 12; j++)
+			{
+				if (solveLabels[j].text == code[i].ToString())
+				{
+					yield return DoInteractionClick(finalKeypad[j]);
+					break;
+				}
+			}
+		}
+	}
+
 	static private readonly string[] ordinals = new string[]
 	{
 		"1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th",

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/StainedGlassComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/StainedGlassComponentSolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -6,6 +7,7 @@ public class StainedGlassComponentSolver : ComponentSolver
 	public StainedGlassComponentSolver(TwitchModule module) :
 		base(module)
 	{
+		component = module.BombComponent.GetComponent(componentType);
 		buttons = Module.BombComponent.GetComponent<KMSelectable>().Children;
 		order = new Dictionary<int, KMSelectable>()
 		{
@@ -65,6 +67,22 @@ public class StainedGlassComponentSolver : ComponentSolver
 			yield return DoInteractionClick(btntopress);
 		}
 	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		object[] panes = component.GetValue<object[]>("pane");
+
+		for (int i = 0; i < 25; i++)
+		{
+			if (!panes[i].GetValue<bool>("broken") && panes[i].GetValue<bool>("toBreak"))
+				yield return DoInteractionClick(buttons[i]);
+		}
+	}
+
+	private static readonly Type componentType = ReflectionHelper.FindType("StainedGlassScript");
+
+	private readonly object component;
 
 	private readonly KMSelectable[] buttons;
 	private readonly Dictionary<int, KMSelectable> order;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/StreetFighterComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/StreetFighterComponentSolver.cs
@@ -42,6 +42,30 @@ public class StreetFighterComponentSolver : ComponentSolver
 		}
 	}
 
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		if (!_component.GetValue<bool>("player1Selected"))
+		{
+			List<int> indices = new List<int>();
+			string must = _component.GetValue<string>("mustContain");
+			for (int i = 0; i < names.Length; i++)
+			{
+				if (names[i].Contains(must))
+					indices.Add(i);
+			}
+			int rand = UnityEngine.Random.Range(0, indices.Count);
+			DoInteractionHighlight(selectables[indices[rand]]);
+			yield return new WaitForSeconds(0.1f);
+			yield return DoInteractionClick(selectables[indices[rand]]);
+			yield return new WaitForSeconds(0.6f);
+		}
+		string correct = _component.GetValue<string>("correctOpponent");
+		DoInteractionHighlight(selectables[Array.IndexOf(names, correct)]);
+		yield return new WaitForSeconds(0.1f);
+		yield return DoInteractionClick(selectables[Array.IndexOf(names, correct)]);
+	}
+
 	private static readonly Type _componentType = ReflectionHelper.FindType("streetFighterScript");
 	private static readonly FieldInfo fighterButtonsField = _componentType.GetField("fighterButton", BindingFlags.Public | BindingFlags.Instance);
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/TheMatrixComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/TheMatrixComponentSolver.cs
@@ -87,6 +87,18 @@ public class TheMatrixComponentSolver : ComponentSolver
 		yield return DoInteractionClick(correctButton);
 	}
 
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		int corTime = _component.GetValue<int>("pressTime");
+		TimerComponent timerComponent = Module.Bomb.Bomb.GetTimer();
+
+		if (!_component.GetValue<bool>("outsideTheMatrix")) yield return DoInteractionClick(Switch);
+		while ((int) timerComponent.TimeRemaining % 10 != corTime) yield return true;
+		if (_component.GetValue<string>("correctPill") == "blue pill") yield return DoInteractionClick(bluePill, 0);
+		else yield return DoInteractionClick(redPill, 0);
+	}
+
 	private readonly KMSelectable Switch;
 	private readonly KMSelectable bluePill;
 	private readonly KMSelectable redPill;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/KeepClickingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/KeepClickingComponentSolver.cs
@@ -15,13 +15,13 @@ public class KeepClickingComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string inputCommand)
 	{
-		if (!inputCommand.Equals("submit") && !inputCommand.StartsWith("click")) yield break;
+		if (!inputCommand.Equals("submit") && !inputCommand.StartsWith("click ")) yield break;
 		if (inputCommand.Equals("submit"))
 		{
 			yield return null;
 			yield return DoInteractionClick(_submitButton, 0);
 		}
-		else if (inputCommand.StartsWith("click") && split.Length == 2)
+		else if (inputCommand.StartsWith("click ") && split.Length == 2)
 		{
 			if (!int.TryParse(split[1], out _)) yield break;
 			if (int.Parse(split[1]) < 1 || int.Parse(split[1]) > 3) yield break;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/SixteenCoinsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/SixteenCoinsComponentSolver.cs
@@ -9,7 +9,7 @@ public class SixteenCoinsComponentSolver : ReflectionComponentSolver
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (split.Length != 2 || !command.StartsWith("press")) yield break;
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
 		if (!int.TryParse(split[1], out _)) yield break;
 		if (int.Parse(split[1]) < 1 || int.Parse(split[1]) > 16) yield break;
 


### PR DESCRIPTION
- Fixed TP supports of all modules I added in a previous wave, all of them had a similar bug where doing something like '!# pressHbWe left' was still accepted as valid
- Added TP support to both Button Order and Strike/Solve
- Added autosolvers to the following: Foreign Exchange Rates, Grocery Store, Memorable Buttons, Stained Glass, Street Fighter, and The Matrix