### PR TITLE
Added FindClaimDelay

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -328,6 +328,11 @@ static class GameCommands
 
 		if (claim)
 		{
+			if (!TwitchGame.Instance.FindClaimEnabled && !OtherModes.TrainingModeOn)
+			{
+				IRCConnection.SendMessageFormat("@{0}, the findclaim command may only be used after {1} seconds have passed.", user, TwitchPlaySettings.data.FindClaimDelay); // Prevents findclaim spam at the start of a bomb
+				return;
+			}
 			if (!TwitchGame.Instance.FindClaimPlayers.ContainsKey(user)) TwitchGame.Instance.FindClaimPlayers.Add(user, 0);
 
 			var _prevClaims = TwitchGame.Instance.FindClaimPlayers[user];

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -506,13 +506,7 @@ public class TwitchGame : MonoBehaviour
 
 	private IEnumerator AddFindClaimDelay()
 	{
-		var delay = TwitchPlaySettings.data.FindClaimDelay;
-		var currentTime = 0f;
-		while (currentTime < delay)
-		{
-			currentTime += Time.deltaTime;
-			yield return null;
-		}
+		yield return new WaitForSeconds(TwitchPlaySettings.data.FindClaimDelay);
 		FindClaimEnabled = true;
 	}
 

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -43,6 +43,7 @@ public class TwitchGame : MonoBehaviour
 	public List<string> EvilPlayers = new List<string>();
 
 	public int FindClaimUse = 0;
+	public bool FindClaimEnabled;
 	public Dictionary<string, int> FindClaimPlayers = new Dictionary<string, int>();
 
 #pragma warning disable 169
@@ -87,6 +88,7 @@ public class TwitchGame : MonoBehaviour
 		}
 
 		StartCoroutine(TwitchPlaysService.Instance.AnimateHeaderVisibility(true));
+		StartCoroutine(AddFindClaimDelay());
 
 		IRCConnection.SendMessage(Bombs.Count == 1
 			? TwitchPlaySettings.data.BombLiveMessage
@@ -272,6 +274,7 @@ public class TwitchGame : MonoBehaviour
 		EvilPlayers.Clear();
 		VSSetFlag = false;
 		QueueEnabled = false;
+		FindClaimEnabled = false;
 		Leaderboard.Instance.BombsAttempted++;
 		// ReSharper disable once DelegateSubtraction
 		ParentService.GetComponent<KMGameInfo>().OnLightsChange -= OnLightsChange;
@@ -499,6 +502,18 @@ public class TwitchGame : MonoBehaviour
 					bomb.FillEdgework();
 			yield return new WaitForSeconds(0.1f);
 		}
+	}
+
+	private IEnumerator AddFindClaimDelay()
+	{
+		var delay = TwitchPlaySettings.data.FindClaimDelay;
+		var currentTime = 0f;
+		while (currentTime < delay)
+		{
+			currentTime += Time.deltaTime;
+			yield return null;
+		}
+		FindClaimEnabled = true;
 	}
 
 	private IEnumerator CheckForBomb()

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -45,6 +45,7 @@ public class TwitchPlaySettingsData
 	public int FindClaimLimit = 3;
 	public int FindClaimTerms = 3;
 	public int FindClaimAddTime = 5;
+	public int FindClaimDelay = 30;
 	public int VoteCountdownTime = 60;
 	public bool EnableVoting = true;
 	public bool EnableVoteSolve = true;


### PR DESCRIPTION
This PR makes it so that you can not use the findclaim command within the first seconds of the bomb specified by the FindClaimDelay variable in the ModSettings.