### PR TITLE
Fix ReflectionHelper with value type properties. Fixes #576

### DIFF
--- a/TwitchPlaysAssembly/Src/Helpers/ReflectionHelper.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/ReflectionHelper.cs
@@ -78,7 +78,7 @@ public static class ReflectionHelper
 		var fieldMember = type.GetCachedMember<FieldInfo>(member);
 		var propertyMember = type.GetCachedMember<PropertyInfo>(member);
 
-		return (T) ((fieldMember != null ? fieldMember.GetValue(target) : default(T)) ?? (propertyMember != null ? propertyMember.GetValue(target, null) : default(T)));
+		return (T) (fieldMember != null ? fieldMember.GetValue(target) : propertyMember != null ? propertyMember.GetValue(target, null) : default(T));
 	}
 
 	public static void SetValue(this Type type, string member, object value, object target = null)


### PR DESCRIPTION
This commit fixes #576 making `ReflectionHelper.GetValue` work properly when reading properties of non-nullable value types.