### PR TITLE
Added a reloadscoreInfo command

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -1230,6 +1230,19 @@ static class GlobalCommands
 		IRCConnectionManagerHoldable.TwitchPlaysDataRefreshed = true;
 		IRCConnection.SendMessage("Data reloaded", user, !isWhisper);
 	}
+	
+	/// <name>Reload Score Info</name>
+	/// <syntax>reloadscoreinfo</syntax>
+	/// <summary>Reloads the scoring info of all modules.</summary>
+	/// <restriction>ScoringManager</restriction>
+	[Command("reloadscoreinfo", AccessLevel.ScoringManager, AccessLevel.ScoringManager)]
+	public static IEnumerator ReloadScoreInfo(string user, bool isWhisper)
+	{
+		yield return ComponentSolverFactory.LoadDefaultInformation();
+
+		IRCConnection.SendMessage("Score info reloaded", user, !isWhisper);
+	}
+
 
 	/// <name>Silence Mode</name>
 	/// <syntax>silencemode</syntax>

--- a/TwitchPlaysAssembly/Src/Helpers/UserAccess.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/UserAccess.cs
@@ -14,7 +14,8 @@ public enum AccessLevel
 	NoPoints = 0x0001,
 	Banned = 0x0002,
 	Defuser = 0x0004,
-
+	ScoringManager = 0x0008,
+	
 	Mod = 0x2000,
 	Admin = 0x4000,
 	SuperUser = 0x8000,
@@ -332,6 +333,8 @@ public static class UserAccess
 				return "No Points";
 			case AccessLevel.Defuser:
 				return "Defuser";
+			case AccessLevel.ScoringManager:
+				return "Scoring Manager";
 			case AccessLevel.Mod:
 				return "Moderator";
 			case AccessLevel.Admin:


### PR DESCRIPTION
This command allows people with the new "ScoringManager" access level to reload the scores of all modules.