### PR TITLE
Help message fix

### DIFF
--- a/TwitchPlaysAssembly/Src/Helpers/UrlHelper.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/UrlHelper.cs
@@ -28,7 +28,7 @@ public class UrlHelper : MonoBehaviour
 
 	public static string ManualFor(string module, string type = "html", bool useVanillaRuleModifier = false) => string.Format(TwitchPlaySettings.data.RepositoryUrl + "{0}/{1}.{2}{3}", type.ToUpper(), NameToUrl(module), type, (useVanillaRuleModifier && type.Equals("html")) ? $"#{VanillaRuleModifier.GetRuleSeed()}" : "");
 
-	private static string NameToUrl(string name) => Uri.EscapeDataString(Uri.UnescapeDataString(name).Replace("'", "’").Split(InvalidCharacters).Join("")).Replace("*", "%2A");
+	private static string NameToUrl(string name) => Uri.EscapeDataString(Uri.UnescapeDataString(name).Replace("'", "’").Split(InvalidCharacters).Join("")).Replace("*", "%2A").Replace("!", "%21");
 
 	private static readonly char[] InvalidCharacters = Path.GetInvalidFileNameChars().Where(c => c != '*').ToArray();
 }


### PR DESCRIPTION
- Exclamation marks appear to break links in Twitch, so alter the escaped URL to also escape the exclamation mark.