### PR TITLE
The massive long awaited update

### DIFF
--- a/Assets/Plugins/Managed/documentation.xml
+++ b/Assets/Plugins/Managed/documentation.xml
@@ -180,6 +180,25 @@
             <syntax>run</syntax>
             <summary>Runs the dynamic mission generator with specific text. If enabled, players can only use this in Training Mode. Otherwise, only admins can access the DMG.</summary>
         </member>
+        <member name="T:DossierCommands">
+            <summary>Commands that can be used in the dossier menu.</summary>
+            <prefix>dossier </prefix>
+        </member>
+        <member name="M:DossierCommands.Select(FloatingHoldable)">
+            <name>Select</name>
+            <syntax>select</syntax>
+            <summary>Selects the currently highlighted item.</summary>
+        </member>
+        <member name="M:DossierCommands.SelectIndex(FloatingHoldable,System.Int32)">
+            <name>Select Index</name>
+            <syntax>select [index]</syntax>
+            <summary>Selects an item based on it's index on the menu.</summary>
+        </member>
+        <member name="M:DossierCommands.Navigate(System.String,System.Nullable{System.Int32})">
+            <name>Up / Down</name>
+            <syntax>up (amount)\ndown (amount)</syntax>
+            <summary>Moves up or down the menu by a number items.</summary>
+        </member>
         <member name="T:FreeplayCommands">
             <summary>Commands for the freeplay briefcase.</summary>
             <prefix>freeplay </prefix>

--- a/TwitchPlaysAssembly/Src/Commands/DossierCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/DossierCommands.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+
+/// <summary>Commands that can be used in the dossier menu.</summary>
+/// <prefix>dossier </prefix>
+public static class DossierCommands
+{
+	/// <name>Select</name>
+	/// <syntax>select</syntax>
+	/// <summary>Selects the currently highlighted item.</summary>
+	[Command(@"select")]
+	public static IEnumerator Select(FloatingHoldable holdable) => SelectOnPage(holdable);
+
+	/// <name>Select Index</name>
+	/// <syntax>select [index]</syntax>
+	/// <summary>Selects an item based on it's index on the menu.</summary>
+	[Command(@"select +(\d+)")]
+	public static IEnumerator SelectIndex(FloatingHoldable holdable, [Group(1)] int index) => SelectOnPage(holdable, index: index);
+
+	/// <name>Up / Down</name>
+	/// <syntax>up (amount)\ndown (amount)</syntax>
+	/// <summary>Moves up or down the menu by a number items.</summary>
+	[Command(@"(up|u|down|d)(?: (\d+))?")]
+	public static IEnumerator Navigate([Group(1)] string direction, [Group(2)] int? optAmount)
+	{
+		var amount = optAmount ?? 1;
+		var offset = direction.StartsWith("u", StringComparison.InvariantCultureIgnoreCase) ? -1 : 1;
+		for (int i = 0; i < amount; i++)
+		{
+			MoveOnPage(offset);
+			yield return new WaitForSeconds(0.2f);
+		}
+	}
+
+	public static void InitializePage(FloatingHoldable holdable)
+	{
+		Selectable holdableSelectable = holdable.GetComponent<Selectable>();
+		var currentPage = Array.Find(holdable.GetComponentsInChildren<Selectable>(false), x => x != holdableSelectable);
+		_currentSelectable = currentPage?.GetCurrentChild();
+		_currentSelectable?.HandleSelect(true);
+		_currentSelectables = currentPage?.Children;
+		_currentSelectableIndex = _currentSelectables?.IndexOf(sel => sel == _currentSelectable) ?? -1;
+	}
+
+	#region Private Methods
+	private static void MoveOnPage(int offset)
+	{
+		if (_currentSelectableIndex == -1 || _currentSelectables == null || _currentSelectable == null)
+			return;
+
+		int oldSelectableIndex = _currentSelectableIndex;
+
+		for (_currentSelectableIndex += offset; _currentSelectableIndex >= 0 && _currentSelectableIndex < _currentSelectables.Length; _currentSelectableIndex += offset)
+		{
+			if (_currentSelectables[_currentSelectableIndex] == null)
+				continue;
+			_currentSelectable.HandleDeselect();
+			_currentSelectable = _currentSelectables[_currentSelectableIndex];
+			_currentSelectable.HandleSelect(true);
+			return;
+		}
+
+		_currentSelectableIndex = oldSelectableIndex;
+	}
+
+	private static IEnumerator SelectOnPage(FloatingHoldable holdable, int index = 0)
+	{
+		if (TwitchPlaysService.Instance.CurrentState != KMGameInfo.State.Gameplay)
+			yield break;
+
+		if (index > 0)
+		{
+			if ((_currentSelectables == null) || (index > _currentSelectables.Length))
+				yield break;
+
+			int oldSelectableIndex = _currentSelectableIndex;
+
+			int i = 0;
+			Selectable newSelectable = null;
+			for (_currentSelectableIndex = 0; _currentSelectableIndex < _currentSelectables.Length; ++_currentSelectableIndex)
+			{
+				if (_currentSelectables[_currentSelectableIndex] == null)
+					continue;
+
+				// Index mode
+				if (++i == index)
+				{
+					newSelectable = _currentSelectables[_currentSelectableIndex];
+					break;
+				}
+			}
+
+			if (newSelectable == null)
+			{
+				_currentSelectableIndex = oldSelectableIndex;
+				yield break;
+			}
+
+			_currentSelectable.HandleDeselect();
+			_currentSelectable = newSelectable;
+		}
+
+		if (_currentSelectable == null)
+			yield break;
+
+		_currentSelectable.HandleSelect(true);
+		KTInputManager.Instance.SelectableManager.Select(_currentSelectable, true);
+
+		// Prevent users from trying to select anything that is not the dossier modifier button
+		if (!_currentSelectable.name.StartsWith("SolveDossierModifier"))
+		{
+			Audio.PlaySound(KMSoundOverride.SoundEffect.Strike, _currentSelectable.transform);
+			IRCConnection.SendMessage("This option is not accessable to Twitch Plays users.");
+			yield break;
+		}
+
+		KTInputManager.Instance.SelectableManager.HandleInteract();
+		_currentSelectable.OnInteractEnded();
+
+		yield return null;
+		InitializePage(holdable);
+	}
+
+	#endregion
+
+	#region Private Fields
+	private static Selectable _currentSelectable = null;
+	private static int _currentSelectableIndex = -1;
+	private static Selectable[] _currentSelectables = null;
+	#endregion
+}

--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -514,6 +514,12 @@ static class ModuleCommands
 			yield break;
 		}
 
+		if (module.Bomb.BackdoorComponent != null && module.Bomb.BackdoorComponent.GetValue<bool>("BeingHacked") && module.BombComponent.GetModuleDisplayName() != "Backdoor Hacking")
+		{
+			IRCConnection.SendMessageFormat(TwitchPlaySettings.data.BackdoorHackingBlock, module.Code, user, module.HeaderText);
+			yield break;
+		}
+
 		Transform tsLight = module.BombComponent.StatusLightParent?.transform.Find("statusLight(Clone)").Find("Component_LED_ERROR(Clone)");
 		if (tsLight != null && tsLight.gameObject.activeSelf)
 		{

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -49,6 +49,12 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["lgndReflex"] = module => new ReflexComponentSolver(module);
 		ModComponentSolverCreators["lgndPayRespects"] = module => new PayRespectsComponentSolver(module);
 
+		//Lone Modules
+		ModComponentSolverCreators["tripleVision"] = module => new TripleVisionComponentSolver(module);
+		ModComponentSolverCreators["SIHTS"] = module => new SIHTSComponentSolver(module);
+		ModComponentSolverCreators["doubleMaze"] = module => new DoubleMazeComponentSolver(module);
+		ModComponentSolverCreators["logicPlumbing"] = module => new LogicPlumbingComponentSolver(module);
+
 		//Asimir Modules
 		ModComponentSolverCreators["murder"] = module => new MurderComponentSolver(module);
 		ModComponentSolverCreators["SeaShells"] = module => new SeaShellsComponentSolver(module);
@@ -99,6 +105,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["xModule"] = module => new XandYComponentSolver(module);
 		ModComponentSolverCreators["yModule"] = module => new XandYComponentSolver(module);
 		ModComponentSolverCreators["imbalance"] = module => new ImbalanceComponentSolver(module);
+		ModComponentSolverCreators["shaker"] = module => new ShakerComponentSolver(module);
 
 		//TheCrazyCodr Modules
 		ModComponentSolverCreators["sqlBasic"] = module => new SQLBasicComponentSolver(module);
@@ -139,6 +146,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["12321"] = module => new OneTwoThreeComponentSolver(module);
 		ModComponentSolverCreators["TechSupport"] = module => new TechSupportComponentSolver(module);
 		ModComponentSolverCreators["factoryCode"] = module => new FactoryCodeComponentSolver(module);
+		ModComponentSolverCreators["SpellingBuzzed"] = module => new SpellingBuzzedComponentSolver(module);
+		ModComponentSolverCreators["BackdoorHacking"] = module => new BackdoorHackingComponentSolver(module);
 
 		//ZekNikZ Modules
 		ModComponentSolverCreators["EdgeworkModule"] = module => new EdgeworkComponentSolver(module);
@@ -162,6 +171,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["LargeFreePassword"] = module => new FreePasswordComponentSolver(module);
 		ModComponentSolverCreators["LargeVanillaPassword"] = module => new LargePasswordComponentSolver(module);
 		ModComponentSolverCreators["TDSNeedyWires"] = module => new NeedyWiresComponentSolver(module);
+		ModComponentSolverCreators["TDSDossierModifier"] = module => new DossierModifierComponentSolver(module);
+		ModComponentSolverCreators["ManualCodes"] = module => new ManualCodesComponentSolver(module);
 
 		//Translated Modules
 		ModComponentSolverCreators["BigButtonTranslated"] = module => new TranslatedButtonComponentSolver(module);
@@ -251,6 +262,10 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["minecraftParody"] = module => new MinecraftParodyShim(module);
 		ModComponentSolverCreators["minecraftCipher"] = module => new MinecraftCipherShim(module);
 		ModComponentSolverCreators["PressX"] = module => new PressXShim(module);
+		ModComponentSolverCreators["iPhone"] = module => new IPhoneShim(module);
+		ModComponentSolverCreators["constellations"] = module => new ConstellationsShim(module);
+		ModComponentSolverCreators["giantsDrink"] = module => new GiantsDrinkShim(module);
+		ModComponentSolverCreators["heraldry"] = module => new HeraldryShim(module);
 
 		// Anti-troll shims - These are specifically meant to allow the troll commands to be disabled.
 		ModComponentSolverCreators["MazeV2"] = module => new AntiTrollShim(module, new Dictionary<string, string> { { "spinme", "Sorry, I am not going to waste time spinning every single pipe 360 degrees." } });
@@ -329,6 +344,12 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["lgndReflex"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Reflex" };
 		ModComponentSolverInformation["lgndPayRespects"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Pay Respects" };
 
+		//Lone
+		ModComponentSolverInformation["tripleVision"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Triple Vision" };
+		ModComponentSolverInformation["SIHTS"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "SI-HTS" };
+		ModComponentSolverInformation["doubleMaze"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Double Maze" };
+		ModComponentSolverInformation["logicPlumbing"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Logic Plumbing" };
+
 		//Mock Army
 		ModComponentSolverInformation["AnagramsModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Anagrams" };
 		ModComponentSolverInformation["Emoji Math"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Emoji Math" };
@@ -367,6 +388,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["xModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "X" };
 		ModComponentSolverInformation["yModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Y" };
 		ModComponentSolverInformation["imbalance"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Imbalance" };
+		ModComponentSolverInformation["shaker"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "The Shaker" };
 
 		//TheCrazyCodr
 		ModComponentSolverInformation["sqlBasic"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "SQL - Basic" };
@@ -410,6 +432,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["12321"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "1-2-3-2-1" };
 		ModComponentSolverInformation["TechSupport"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Tech Support" };
 		ModComponentSolverInformation["factoryCode"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Factory Code" };
+		ModComponentSolverInformation["SpellingBuzzed"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Spelling Buzzed" };
+		ModComponentSolverInformation["BackdoorHacking"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Backdoor Hacking" };
 
 		//GoodHood
 		ModComponentSolverInformation["buttonOrder"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Button Order" };
@@ -452,6 +476,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["LargeFreePassword"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Large Free Password" };
 		ModComponentSolverInformation["LargeVanillaPassword"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Large Password" };
 		ModComponentSolverInformation["TDSNeedyWires"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Needy Wires" };
+		ModComponentSolverInformation["TDSDossierModifier"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Dossier Modifier" };
+		ModComponentSolverInformation["ManualCodes"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Manual Codes" };
 
 		//Translated Modules
 		ModComponentSolverInformation["BigButtonTranslated"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Big Button Translated" };
@@ -460,12 +486,13 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["WhosOnFirstTranslated"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Who's on First Translated" };
 		ModComponentSolverInformation["VentGasTranslated"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Vent Gas Translated" };
 
-		//Shim added in between Twitch Plays and module (This allows overriding a specific command, or for enforcing unsubmittable penalty)
+		//Shim added in between Twitch Plays and module (This allows overriding a specific command, adding a new command, or for fixes such as enforcing unsubmittable penalty)
 		ModComponentSolverInformation["Color Generator"] = new ModuleInformation { moduleDisplayName = "Color Generator", helpText = "Submit a color using \"!{0} press bigred 1,smallred 2,biggreen 1,smallblue 1\" !{0} press <buttonname> <amount of times to push>. If you want to be silly, you can have this module change the color of the status light when solved with \"!{0} press smallblue UseRedOnSolve\" or UseOffOnSolve. You can make this module tell a story with !{0} tellmeastory, make a needy sound with !{0} needystart or !{0} needyend, fake strike with !{0} faksestrike, and troll with !{0} troll", helpTextOverride = true };
 		ModComponentSolverInformation["ExtendedPassword"] = new ModuleInformation { moduleDisplayName = "Extended Password" };
 		ModComponentSolverInformation["ColourFlashES"] = new ModuleInformation { moduleDisplayName = "Colour Flash ES", helpText = "Submit the correct response with !{0} press yes 3, or !{0} press no 5.", helpTextOverride = true };
 		ModComponentSolverInformation["PressX"] = new ModuleInformation { moduleDisplayName = "Press X", helpText = "Submit button presses using !{0} press x on 1 or !{0} press y on 23 or !{0} press a on 8 28 48. Acceptable buttons are a, b, x and y.", helpTextOverride = true };
 		ModComponentSolverInformation["ShapesBombs"] = new ModuleInformation { moduleDisplayName = "Shapes And Bombs", helpText = "!{0} press A1 B39 C123... (column [A to E] and row [1 to 8] to press [you can input multiple rows in the same column]) | !{0} display/disp/d 4 (displays sequence number [0 to 14]) | !{0} reset/res/r (resets initial letter) | !{0} empty/emp/e (empties lit squares) | !{0} submit/sub/s (submits current shape) | !{0} colorblind/cb (enables colorblind mode)", helpTextOverride = true };
+		ModComponentSolverInformation["taxReturns"] = new ModuleInformation { moduleDisplayName = "Tax Returns", helpText = "Submit your taxes using !{0} submit <number>. Page left and right using !{0} left (number) and !{0} right (number). Briefly view the HRMC terminal to see the deadline with !{0} deadline.", helpTextOverride = true, announceModule = true };
 
 		//These modules have troll commands built in.
 		ModComponentSolverInformation["MazeV2"] = new ModuleInformation { moduleDisplayName = "Plumbing" };
@@ -574,7 +601,6 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["modulo"] = new ModuleInformation { DoesTheRightThing = false };
 		ModComponentSolverInformation["numberCipher"] = new ModuleInformation { DoesTheRightThing = false };
 		ModComponentSolverInformation["retirement"] = new ModuleInformation { DoesTheRightThing = false };
-		ModComponentSolverInformation["taxReturns"] = new ModuleInformation { announceModule = true };
 		ModComponentSolverInformation["theSwan"] = new ModuleInformation { CameraPinningAlwaysAllowed = true, announceModule = true };
 		ModComponentSolverInformation["wire"] = new ModuleInformation { DoesTheRightThing = false };
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/BakersDozenBagels/ShakerComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/BakersDozenBagels/ShakerComponentSolver.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections;
+
+public class ShakerComponentSolver : ReflectionComponentSolver
+{
+	public ShakerComponentSolver(TwitchModule module) :
+		base(module, "ShakerScript", "!{0} toggle <p1> (p2)... [Toggles the light(s) in the specified position(s)] | !{0} submit [Presses the center of the module] | Valid positions are tl, tr, bl, br, or 1-4 in reading order | To shake the balls around use TP's tilt command")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (command.Equals("submit"))
+		{
+			yield return null;
+			yield return Click(4, 0);
+		}
+		else
+		{
+			if (split.Length < 2 || !command.StartsWith("toggle ")) yield break;
+			for (int i = 1; i < split.Length; i++)
+			{
+				if (!split[i].EqualsAny("tl", "tr", "bl", "br", "1", "2", "3", "4")) yield break;
+			}
+
+			yield return null;
+			string[] positions = new string[] { "bl", "tl", "br", "tr" };
+			string[] positions2 = new string[] { "3", "1", "4", "2" };
+			for (int i = 1; i < split.Length; i++)
+			{
+				int index = Array.IndexOf(positions, split[i]);
+				if (index == -1)
+					index = Array.IndexOf(positions2, split[i]);
+				yield return Click(index, .2f);
+			}
+		}
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/BakersDozenBagels/XandYComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/BakersDozenBagels/XandYComponentSolver.cs
@@ -8,13 +8,19 @@ public class XandYComponentSolver : ComponentSolver
 	public XandYComponentSolver(TwitchModule module) :
 		base(module)
 	{
-		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "!alarm snooze <#> [Press the snooze button '#' times]");
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "!alarm help [View the commands for the alarm clock] | !{0} cover [Presses the cover to solve the module if no alarm clock is present]");
 	}
 
 	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)
 	{
+		if (!inputCommand.Equals("cover")) yield break;
+
 		yield return null;
-		yield return "sendtochaterror Please use the !alarm snooze command to interact with this module";
+		AlarmClock alarm = UnityEngine.Object.FindObjectOfType<AlarmClock>();
+		if (alarm == null)
+			yield return DoInteractionClick(Module.Selectable.Children[0], 0);
+		else
+			yield return "sendtochaterror Command rejected since an alarm clock present.";
 	}
 
 	protected override IEnumerator ForcedSolveIEnumerator()
@@ -24,23 +30,29 @@ public class XandYComponentSolver : ComponentSolver
 
 		yield return null;
 
-		Selectable snooze = UnityEngine.Object.FindObjectOfType<AlarmClock>().SnoozeButton.GetComponent<Selectable>();
-		object component = Module.BombComponent.GetComponent(xyType);
-
-		int answer = 11 + component.GetValue<int>("val");
-		int current = component.GetValue<int>("currentCount");
-
-		if (current > answer)
+		AlarmClock alarm = UnityEngine.Object.FindObjectOfType<AlarmClock>();
+		if (alarm != null)
 		{
-			((MonoBehaviour) component).StopAllCoroutines();
-			yield break;
+			Selectable snooze = alarm.SnoozeButton.GetComponent<Selectable>();
+			object component = Module.BombComponent.GetComponent(xyType);
+
+			int answer = 11 + component.GetValue<int>("val");
+			int current = component.GetValue<int>("currentCount");
+
+			if (current > answer)
+			{
+				((MonoBehaviour) component).StopAllCoroutines();
+				yield break;
+			}
+			while (current < answer)
+			{
+				snooze.Trigger();
+				current++;
+				yield return new WaitForSeconds(.1f);
+			}
+			while (!Module.BombComponent.IsSolved) yield return null;
 		}
-		while (current < answer)
-		{
-			snooze.Trigger();
-			current++;
-			yield return new WaitForSeconds(.1f);
-		}
-		while (!Module.BombComponent.IsSolved) yield return null;
+		else
+			yield return DoInteractionClick(Module.Selectable.Children[0], 0);
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/DoubleMazeComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/DoubleMazeComponentSolver.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+
+public class DoubleMazeComponentSolver : ReflectionComponentSolver
+{
+	public DoubleMazeComponentSolver(TwitchModule module) :
+		base(module, "doubleMaze", "!{0} press <up/down/left/right/clockwise/counter-clockwise/flip> [Presses an arrow button that does the specified action] | Actions can be simplified to their first letter except for rotations which are clock/cw and counter/ccw | Presses can be chained using spaces, commas, or semicolons")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length < 2 || !command.StartsWith("press ")) yield break;
+		for (int i = 1; i < split.Length; i++)
+		{
+			if (!split[i].EqualsAny("up", "u", "down", "d", "left", "l", "right", "r", "clockwise", "clock", "cw", "counter-clockwise", "counter", "ccw", "flip", "f")) yield break;
+		}
+
+		yield return null;
+		for (int i = 1; i < split.Length; i++)
+		{
+			while (!_component.GetValue<bool>("interactable")) yield return "trycancel";
+			switch (split[i])
+			{
+				case "flip":
+				case "f":
+					yield return Click(0, 0);
+					break;
+				case "left":
+				case "l":
+					yield return Click(1, 0);
+					break;
+				case "up":
+				case "u":
+					yield return Click(2, 0);
+					break;
+				case "right":
+				case "r":
+					yield return Click(3, 0);
+					break;
+				case "down":
+				case "d":
+					yield return Click(4, 0);
+					break;
+				case "clockwise":
+				case "clock":
+				case "cw":
+					yield return Click(5, 0);
+					break;
+				default:
+					yield return Click(6, 0);
+					break;
+			}
+		}
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
@@ -4,13 +4,12 @@ using System.Text.RegularExpressions;
 public class LogicPlumbingComponentSolver : ReflectionComponentSolver
 {
 	public LogicPlumbingComponentSolver(TwitchModule module) :
-		base(module, "logicPlumbing", "!{0} swap <coord1> <coord2> [Swaps the tiles at the specified coordinates (letter = column, number = row)] | !{0} check [Holds the top left button briefly] | Swaps can be chained using spaces, commas, or semicolons")
+		base(module, "logicPlumbing", "!{0} swap <coord1> <coord2> [Swaps the tiles at the specified coordinates] | !{0} check [Holds the top left button briefly] | Valid coordinates are A1-F6 with letters as column and numbers as row | Swaps can be chained using spaces, commas, or semicolons")
 	{
 	}
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (_component.GetValue<bool>("solved")) yield break;
 		if (command.StartsWith("swap "))
 		{
 			if (split.Length < 3 || split.Length % 2 == 0) yield break;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
@@ -21,7 +21,7 @@ public class LogicPlumbingComponentSolver : ReflectionComponentSolver
 			yield return null;
 			for (int i = 1; i < split.Length; i++)
 			{
-				yield return Click((int.Parse(split[i][1].ToString()) - 1) * 6 + "abcdef".IndexOf(split[i][0]));
+				yield return Click(split[i][1].ToIndex() * 6 + split[i][0].ToIndex());
 			}
 		}
 		else if (command.Equals("check"))

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/LogicPlumbingComponentSolver.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Text.RegularExpressions;
+
+public class LogicPlumbingComponentSolver : ReflectionComponentSolver
+{
+	public LogicPlumbingComponentSolver(TwitchModule module) :
+		base(module, "logicPlumbing", "!{0} swap <coord1> <coord2> [Swaps the tiles at the specified coordinates (letter = column, number = row)] | !{0} check [Holds the top left button briefly] | Swaps can be chained using spaces, commas, or semicolons")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (_component.GetValue<bool>("solved")) yield break;
+		if (command.StartsWith("swap "))
+		{
+			if (split.Length < 3 || split.Length % 2 == 0) yield break;
+			for (int i = 1; i < split.Length; i++)
+			{
+				if (!Regex.IsMatch(split[i], @"^\s*[a-f][1-6]\s*$")) yield break;
+			}
+
+			yield return null;
+			for (int i = 1; i < split.Length; i++)
+			{
+				yield return Click((int.Parse(split[i][1].ToString()) - 1) * 6 + "abcdef".IndexOf(split[i][0]));
+			}
+		}
+		else if (command.Equals("check"))
+		{
+			yield return null;
+			DoInteractionStart(selectables[36]);
+			while (_component.GetValue<int>("waveStep") <= 24) yield return "trycancel";
+			DoInteractionEnd(selectables[36]);
+			if (_component.GetValue<bool>("solved")) yield return "solve";
+		}
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/SIHTSComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/SIHTSComponentSolver.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+
+public class SIHTSComponentSolver : CommandComponentSolver
+{
+	public SIHTSComponentSolver(TwitchModule module) :
+		base(module, "SIHTS", "!{0} underhand/flick [Set whether you will flick or underhand toss the coin] | !{0} increased/decreased/unchanged [Sets the coin acceleration]")
+	{
+		_underhand = (KMSelectable) UnderhandField.GetValue(_component);
+		_flick = (KMSelectable) FlickField.GetValue(_component);
+		_unchanged = (KMSelectable) UnchangedField.GetValue(_component);
+		_increased = (KMSelectable) IncreasedField.GetValue(_component);
+		_decreased = (KMSelectable) DecreasedField.GetValue(_component);
+	}
+
+	private IEnumerator Underhand(CommandParser _)
+	{
+		_.Literal("underhand");
+
+		yield return null;
+		yield return DoInteractionClick(_underhand);
+	}
+
+	private IEnumerator Flick(CommandParser _)
+	{
+		_.Literal("flick");
+
+		yield return null;
+		yield return DoInteractionClick(_flick);
+	}
+	private IEnumerator Unchanged(CommandParser _)
+	{
+		_.Literal("unchanged");
+
+		yield return null;
+		yield return DoInteractionClick(_unchanged);
+	}
+
+	private IEnumerator Increased(CommandParser _)
+	{
+		_.Literal("increased");
+
+		yield return null;
+		yield return DoInteractionClick(_increased);
+	}
+
+	private IEnumerator Decreased(CommandParser _)
+	{
+		_.Literal("decreased");
+
+		yield return null;
+		yield return DoInteractionClick(_decreased);
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		if (TossTypeValue == 0 && !UHPressedValue)
+			yield return DoInteractionClick(_underhand);
+		else if (TossTypeValue == 1 && !FPressedValue)
+			yield return DoInteractionClick(_flick);
+
+		if (ComponentType.CallMethod<double>("floatToEV", _component, UHNoIntValue % 1.0) == TossValue || ComponentType.CallMethod<double>("floatToEV", _component, FNoIntValue % 1.0) == TossValue)
+			yield return DoInteractionClick(_unchanged);
+		else if (ComponentType.CallMethod<double>("floatToEV", _component, UHDecAccValue % 1.0) == TossValue || ComponentType.CallMethod<double>("floatToEV", _component, FDecAccValue % 1.0) == TossValue)
+			yield return DoInteractionClick(VegemiteValue ? _increased : _decreased);
+		else
+			yield return DoInteractionClick(VegemiteValue ? _decreased : _increased);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("SIHTS");
+	private static readonly FieldInfo UnderhandField = ComponentType.GetField("underhandSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo FlickField = ComponentType.GetField("flickSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo UnchangedField = ComponentType.GetField("noIntSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo IncreasedField = ComponentType.GetField("incAccSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo DecreasedField = ComponentType.GetField("decAccSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo VegemiteField = ComponentType.GetField("vegemite", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo UHPressedField = ComponentType.GetField("UHPressed", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo FPressedField = ComponentType.GetField("FPressed", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo TossTypeField = ComponentType.GetField("requiredTossType", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo TossField = ComponentType.GetField("requiredToss", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo UHNoIntField = ComponentType.GetField("UH_noIntRot", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo FNoIntField = ComponentType.GetField("F_noIntRot", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo UHDecAccField = ComponentType.GetField("UH_decAccRot", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo FDecAccField = ComponentType.GetField("F_decAccRot", BindingFlags.NonPublic | BindingFlags.Instance);
+
+	private readonly KMSelectable _underhand;
+	private readonly KMSelectable _flick;
+	private readonly KMSelectable _unchanged;
+	private readonly KMSelectable _increased;
+	private readonly KMSelectable _decreased;
+
+	private bool VegemiteValue => (bool) VegemiteField.GetValue(_component);
+	private bool UHPressedValue => (bool) UHPressedField.GetValue(_component);
+	private bool FPressedValue => (bool) FPressedField.GetValue(_component);
+	private int TossTypeValue => (int) TossTypeField.GetValue(_component);
+	private double TossValue => (int) TossField.GetValue(_component);
+	private double UHNoIntValue => (double) UHNoIntField.GetValue(_component);
+	private double FNoIntValue => (double) FNoIntField.GetValue(_component);
+	private double UHDecAccValue => (double) UHDecAccField.GetValue(_component);
+	private double FDecAccValue => (double) FDecAccField.GetValue(_component);
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+public class TripleVisionComponentSolver : CommandComponentSolver
+{
+	public TripleVisionComponentSolver(TwitchModule module) :
+		base(module, "tripleVision", "!{0} press <coord> [Presses the panel at the specified coordinate] | Valid coordinates are A1-H8 with letters as column and numbers as row")
+	{
+		_buttons = (KMSelectable[]) ButtonsField.GetValue(_component);
+	}
+
+	private IEnumerator Press(CommandParser _)
+	{
+		_.Literal("press");
+		_.Regex("[a-h][1-8]", out Match match);
+
+		if (match.Success)
+		{
+			yield return null;
+			char[] letters = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
+			int letIndex = Array.IndexOf(letters, match.Groups[0].Value[0]);
+			yield return DoInteractionClick(_buttons[(int.Parse(match.Groups[0].Value[1].ToString()) - 1) * 8 + letIndex]);
+		}
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		yield return DoInteractionClick(_buttons[SolutionValue]);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("tripleVision");
+	private static readonly FieldInfo ButtonsField = ComponentType.GetField("gridSel", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo SolutionValueField = ComponentType.GetField("goal", BindingFlags.NonPublic | BindingFlags.Instance);
+
+	private readonly KMSelectable[] _buttons;
+
+	private int SolutionValue => (int) SolutionValueField.GetValue(_component);
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Text.RegularExpressions;
 
 public class TripleVisionComponentSolver : CommandComponentSolver
@@ -14,13 +13,9 @@ public class TripleVisionComponentSolver : CommandComponentSolver
 		_.Literal("press");
 		_.Regex("[a-h][1-8]", out Match match);
 
-		if (match.Success)
-		{
-			yield return null;
-			char[] letters = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
-			int letIndex = Array.IndexOf(letters, match.Groups[0].Value[0]);
-			yield return Click((int.Parse(match.Groups[0].Value[1].ToString()) - 1) * 8 + letIndex);
-		}
+		yield return null;
+		int letIndex = match.Groups[0].Value[0].ToIndex();
+		yield return Click(match.Groups[0].Value[1].ToIndex() * 8 + letIndex);
 	}
 
 	protected override IEnumerator ForcedSolveIEnumerator()

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/TripleVisionComponentSolver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Reflection;
 using System.Text.RegularExpressions;
 
 public class TripleVisionComponentSolver : CommandComponentSolver
@@ -8,7 +7,6 @@ public class TripleVisionComponentSolver : CommandComponentSolver
 	public TripleVisionComponentSolver(TwitchModule module) :
 		base(module, "tripleVision", "!{0} press <coord> [Presses the panel at the specified coordinate] | Valid coordinates are A1-H8 with letters as column and numbers as row")
 	{
-		_buttons = (KMSelectable[]) ButtonsField.GetValue(_component);
 	}
 
 	private IEnumerator Press(CommandParser _)
@@ -21,21 +19,13 @@ public class TripleVisionComponentSolver : CommandComponentSolver
 			yield return null;
 			char[] letters = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
 			int letIndex = Array.IndexOf(letters, match.Groups[0].Value[0]);
-			yield return DoInteractionClick(_buttons[(int.Parse(match.Groups[0].Value[1].ToString()) - 1) * 8 + letIndex]);
+			yield return Click((int.Parse(match.Groups[0].Value[1].ToString()) - 1) * 8 + letIndex);
 		}
 	}
 
 	protected override IEnumerator ForcedSolveIEnumerator()
 	{
 		yield return null;
-		yield return DoInteractionClick(_buttons[SolutionValue]);
+		yield return Click(_component.GetValue<int>("goal"));
 	}
-
-	private static readonly Type ComponentType = ReflectionHelper.FindType("tripleVision");
-	private static readonly FieldInfo ButtonsField = ComponentType.GetField("gridSel", BindingFlags.Public | BindingFlags.Instance);
-	private static readonly FieldInfo SolutionValueField = ComponentType.GetField("goal", BindingFlags.NonPublic | BindingFlags.Instance);
-
-	private readonly KMSelectable[] _buttons;
-
-	private int SolutionValue => (int) SolutionValueField.GetValue(_component);
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -9,8 +8,7 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 	public BackdoorHackingComponentSolver(TwitchModule module) :
 		base(module, "BackdoorHacking", "!{0} reconnect [Presses the reconnect button] | !{0} buy <1-3> [Presses the specified buy button from top to bottom] | !{0} _ [Presses the spacebar] | !{0} qwerty [Presses keys on the keyboard]")
 	{
-		_reconnect = (KMSelectable) ReconnectField.GetValue(_component);
-		_buy = (KMSelectable[]) BuyField.GetValue(_component);
+		UsableKeysValue = _component.GetValue<string>("TheLetters");
 	}
 
 	private IEnumerator Reconnect(CommandParser _)
@@ -18,7 +16,7 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		_.Literal("reconnect");
 
 		yield return null;
-		yield return DoInteractionClick(_reconnect);
+		yield return Click(0);
 	}
 
 	private IEnumerator Buy(CommandParser _)
@@ -27,7 +25,7 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		_.Integer(out int index, 1, 3);
 
 		yield return null;
-		yield return DoInteractionClick(_buy[index - 1]);
+		yield return Click(index - 1);
 	}
 
 	private IEnumerator AnyKeyPress(CommandParser _)
@@ -38,37 +36,27 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		yield return null;
 		foreach (char key in input)
 		{
-			if (StateValue == 2 && key == '_')
+			if (_component.GetValue<int>("CurrentState") == 2 && key == '_')
 				ComponentType.CallMethod("ZoneWallPress", _component);
-			else if (StateValue == 3)
+			else if (_component.GetValue<int>("CurrentState") == 3)
 				ComponentType.CallMethod("MemoryFraggerPress", _component, UsableKeysValue.IndexOf(key));
-			else if (StateValue == 4)
+			else if (_component.GetValue<int>("CurrentState") == 4)
 				ComponentType.CallMethod("NodeHackerPress", _component, UsableKeysValue.IndexOf(key));
-			else if (StateValue == 5 && (key == '^' || key == 'W') && SelectionValue > 4)
+			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '^' || key == 'W') && _component.GetValue<int>("ActualSelection") > 4)
 				ComponentType.CallMethod("StackPusherUp", _component);
-			else if (StateValue == 5 && (key == '<' || key == 'A') && SelectionValue % 5 != 0)
+			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '<' || key == 'A') && _component.GetValue<int>("ActualSelection") % 5 != 0)
 				ComponentType.CallMethod("StackPusherLeft", _component);
-			else if (StateValue == 5 && (key == '/' || key == 'S') && SelectionValue < 20)
+			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '/' || key == 'S') && _component.GetValue<int>("ActualSelection") < 20)
 				ComponentType.CallMethod("StackPusherDown", _component);
-			else if (StateValue == 5 && (key == '>' || key == 'D') && SelectionValue % 5 != 4)
+			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '>' || key == 'D') && _component.GetValue<int>("ActualSelection") % 5 != 4)
 				ComponentType.CallMethod("StackPusherRight", _component);
-			else if (StateValue == 5 && key == '_')
+			else if (_component.GetValue<int>("CurrentState") == 5 && key == '_')
 				ComponentType.CallMethod("StackPusherSpace", _component);
 			yield return new WaitForSeconds(.1f);
 		}
 	}
 
 	private static readonly Type ComponentType = ReflectionHelper.FindType("BackdoorHacking");
-	private static readonly FieldInfo ReconnectField = ComponentType.GetField("Button", BindingFlags.Public | BindingFlags.Instance);
-	private static readonly FieldInfo BuyField = ComponentType.GetField("BuyButtons", BindingFlags.Public | BindingFlags.Instance);
-	private static readonly FieldInfo StateField = ComponentType.GetField("CurrentState", BindingFlags.NonPublic | BindingFlags.Instance);
-	private static readonly FieldInfo SelectionField = ComponentType.GetField("ActualSelection", BindingFlags.NonPublic | BindingFlags.Instance);
-	private static readonly FieldInfo UsableKeysField = ComponentType.GetField("TheLetters", BindingFlags.NonPublic | BindingFlags.Instance);
 
-	private readonly KMSelectable _reconnect;
-	private readonly KMSelectable[] _buy;
-
-	private int StateValue => (int) StateField.GetValue(_component);
-	private int SelectionValue => (int) SelectionField.GetValue(_component);
-	private string UsableKeysValue => (string) UsableKeysField.GetValue(_component);
+	private string UsableKeysValue;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class BackdoorHackingComponentSolver : CommandComponentSolver
+{
+	public BackdoorHackingComponentSolver(TwitchModule module) :
+		base(module, "BackdoorHacking", "!{0} reconnect [Presses the reconnect button] | !{0} buy <1-3> [Presses the specified buy button from top to bottom] | !{0} _ [Presses the spacebar] | !{0} qwerty [Presses keys on the keyboard]")
+	{
+		_reconnect = (KMSelectable) ReconnectField.GetValue(_component);
+		_buy = (KMSelectable[]) BuyField.GetValue(_component);
+	}
+
+	private IEnumerator Reconnect(CommandParser _)
+	{
+		_.Literal("reconnect");
+
+		yield return null;
+		yield return DoInteractionClick(_reconnect);
+	}
+
+	private IEnumerator Buy(CommandParser _)
+	{
+		_.Literal("buy");
+		_.Integer(out int index, 1, 3);
+
+		yield return null;
+		yield return DoInteractionClick(_buy[index - 1]);
+	}
+
+	private IEnumerator AnyKeyPress(CommandParser _)
+	{
+		_.Regex("[a-z0-9_<^>/]+", out Match match);
+		string input = match.Groups[0].Value.ToUpper();
+
+		yield return null;
+		foreach (char key in input)
+		{
+			if (StateValue == 2 && key == '_')
+				ComponentType.CallMethod("ZoneWallPress", _component);
+			else if (StateValue == 3)
+				ComponentType.CallMethod("MemoryFraggerPress", _component, UsableKeysValue.IndexOf(key));
+			else if (StateValue == 4)
+				ComponentType.CallMethod("NodeHackerPress", _component, UsableKeysValue.IndexOf(key));
+			else if (StateValue == 5 && (key == '^' || key == 'W') && SelectionValue > 4)
+				ComponentType.CallMethod("StackPusherUp", _component);
+			else if (StateValue == 5 && (key == '<' || key == 'A') && SelectionValue % 5 != 0)
+				ComponentType.CallMethod("StackPusherLeft", _component);
+			else if (StateValue == 5 && (key == '/' || key == 'S') && SelectionValue < 20)
+				ComponentType.CallMethod("StackPusherDown", _component);
+			else if (StateValue == 5 && (key == '>' || key == 'D') && SelectionValue % 5 != 4)
+				ComponentType.CallMethod("StackPusherRight", _component);
+			else if (StateValue == 5 && key == '_')
+				ComponentType.CallMethod("StackPusherSpace", _component);
+			yield return new WaitForSeconds(.1f);
+		}
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("BackdoorHacking");
+	private static readonly FieldInfo ReconnectField = ComponentType.GetField("Button", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo BuyField = ComponentType.GetField("BuyButtons", BindingFlags.Public | BindingFlags.Instance);
+	private static readonly FieldInfo StateField = ComponentType.GetField("CurrentState", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo SelectionField = ComponentType.GetField("ActualSelection", BindingFlags.NonPublic | BindingFlags.Instance);
+	private static readonly FieldInfo UsableKeysField = ComponentType.GetField("TheLetters", BindingFlags.NonPublic | BindingFlags.Instance);
+
+	private readonly KMSelectable _reconnect;
+	private readonly KMSelectable[] _buy;
+
+	private int StateValue => (int) StateField.GetValue(_component);
+	private int SelectionValue => (int) SelectionField.GetValue(_component);
+	private string UsableKeysValue => (string) UsableKeysField.GetValue(_component);
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
@@ -25,7 +25,7 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		_.Integer(out int index, 1, 3);
 
 		yield return null;
-		yield return Click(index - 1);
+		yield return Click(index);
 	}
 
 	private IEnumerator AnyKeyPress(CommandParser _)

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/BackdoorHackingComponentSolver.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -9,6 +8,7 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		base(module, "BackdoorHacking", "!{0} reconnect [Presses the reconnect button] | !{0} buy <1-3> [Presses the specified buy button from top to bottom] | !{0} _ [Presses the spacebar] | !{0} qwerty [Presses keys on the keyboard]")
 	{
 		UsableKeysValue = _component.GetValue<string>("TheLetters");
+		module.Bomb.BackdoorComponent = _component;
 	}
 
 	private IEnumerator Reconnect(CommandParser _)
@@ -36,27 +36,26 @@ public class BackdoorHackingComponentSolver : CommandComponentSolver
 		yield return null;
 		foreach (char key in input)
 		{
-			if (_component.GetValue<int>("CurrentState") == 2 && key == '_')
-				ComponentType.CallMethod("ZoneWallPress", _component);
-			else if (_component.GetValue<int>("CurrentState") == 3)
-				ComponentType.CallMethod("MemoryFraggerPress", _component, UsableKeysValue.IndexOf(key));
-			else if (_component.GetValue<int>("CurrentState") == 4)
-				ComponentType.CallMethod("NodeHackerPress", _component, UsableKeysValue.IndexOf(key));
-			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '^' || key == 'W') && _component.GetValue<int>("ActualSelection") > 4)
-				ComponentType.CallMethod("StackPusherUp", _component);
-			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '<' || key == 'A') && _component.GetValue<int>("ActualSelection") % 5 != 0)
-				ComponentType.CallMethod("StackPusherLeft", _component);
-			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '/' || key == 'S') && _component.GetValue<int>("ActualSelection") < 20)
-				ComponentType.CallMethod("StackPusherDown", _component);
-			else if (_component.GetValue<int>("CurrentState") == 5 && (key == '>' || key == 'D') && _component.GetValue<int>("ActualSelection") % 5 != 4)
-				ComponentType.CallMethod("StackPusherRight", _component);
-			else if (_component.GetValue<int>("CurrentState") == 5 && key == '_')
-				ComponentType.CallMethod("StackPusherSpace", _component);
+			int state = _component.GetValue<int>("CurrentState");
+			if (state == 2 && key == '_')
+				_component.CallMethod("ZoneWallPress");
+			else if (state == 3)
+				_component.CallMethod("MemoryFraggerPress", UsableKeysValue.IndexOf(key));
+			else if (state == 4)
+				_component.CallMethod("NodeHackerPress", UsableKeysValue.IndexOf(key));
+			else if (state == 5 && key.EqualsAny('^', 'W') && _component.GetValue<int>("ActualSelection") > 4)
+				_component.CallMethod("StackPusherUp");
+			else if (state == 5 && key.EqualsAny('<', 'A') && _component.GetValue<int>("ActualSelection") % 5 != 0)
+				_component.CallMethod("StackPusherLeft");
+			else if (state == 5 && key.EqualsAny('/', 'S') && _component.GetValue<int>("ActualSelection") < 20)
+				_component.CallMethod("StackPusherDown");
+			else if (state == 5 && key.EqualsAny('>', 'D') && _component.GetValue<int>("ActualSelection") % 5 != 4)
+				_component.CallMethod("StackPusherRight");
+			else if (state == 5 && key == '_')
+				_component.CallMethod("StackPusherSpace");
 			yield return new WaitForSeconds(.1f);
 		}
 	}
 
-	private static readonly Type ComponentType = ReflectionHelper.FindType("BackdoorHacking");
-
-	private string UsableKeysValue;
+	private readonly string UsableKeysValue;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/SpellingBuzzedComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/SpellingBuzzedComponentSolver.cs
@@ -36,6 +36,6 @@ public class SpellingBuzzedComponentSolver : ReflectionComponentSolver
 		}
 	}
 
-	private string _displayedLetters;
-	private List<KMSelectable> _keypadButtons;
+	private readonly string _displayedLetters;
+	private readonly List<KMSelectable> _keypadButtons;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/SpellingBuzzedComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/SpellingBuzzedComponentSolver.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class SpellingBuzzedComponentSolver : ReflectionComponentSolver
+{
+	public SpellingBuzzedComponentSolver(TwitchModule module) :
+		base(module, "SpellingBuzzedModule", "Use !{0} submit DRUNK to submit that word into the module.")
+	{
+		_keypadButtons = selectables.ToList();
+		_keypadButtons.RemoveAt(2);
+		_keypadButtons.RemoveAt(7);
+		for (int buttonIndex = 0; buttonIndex < 7; buttonIndex++)
+			_displayedLetters += _keypadButtons[buttonIndex].transform.Find("ButtonText").GetComponent<TextMesh>().text;
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		command = command.Trim().ToUpperInvariant();
+		string display = _component.GetValue<GameObject>("displayText").GetComponent<TextMesh>().text;
+		Match m = Regex.Match(command, @"^SUBMIT\s+([" + _displayedLetters + "]+)$"); //Will only allow letters on the module.
+		if (m.Success)
+		{
+			yield return null;
+			if (display.Length != 0 && !m.Groups[1].Value.StartsWith(display))
+				yield return Click(8, 0.15f);
+			display = _component.GetValue<GameObject>("displayText").GetComponent<TextMesh>().text;
+			foreach (char letter in m.Groups[1].Value.Skip(display.Length))
+			{
+				_keypadButtons[_displayedLetters.IndexOf(letter)].OnInteract();
+				yield return new WaitForSeconds(0.15f);
+			}
+			yield return Click(2, 0);
+		}
+	}
+
+	private string _displayedLetters;
+	private List<KMSelectable> _keypadButtons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
@@ -10,6 +10,7 @@ public class AnagramsComponentSolver : ComponentSolver
 	{
 		_buttons = module.BombComponent.GetComponent<KMSelectable>().Children;
 		string modType = GetModuleType();
+		_component = Module.BombComponent.GetComponent(ReflectionHelper.FindType(modType));
 		ModInfo = ComponentSolverFactory.GetModuleInfo(modType, "Submit your answer with !{0} submit poodle");
 	}
 
@@ -61,5 +62,52 @@ public class AnagramsComponentSolver : ComponentSolver
 		yield return DoInteractionClick(_buttons[7]);
 	}
 
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		string curr = _component.GetValue<TextMesh>("AnswerDisplay").text;
+		IList ans = new List<string>();
+		if (GetModuleType().Equals("AnagramsModule"))
+		{
+			IList temp = _component.GetValue<IList>("_solution");
+			for (int i = 0; i < temp.Count; i++)
+				ans.Add(temp[i]);
+		}
+		else
+			ans.Add(_component.GetValue<string>("_solution"));
+		if (curr.Length > 6)
+		{
+			yield return DoInteractionClick(_buttons[3]);
+			curr = "";
+		}
+		for (int j = 0; j < ans.Count; j++)
+		{
+			for (int i = 0; i < curr.Length; i++)
+			{
+				if (curr[i] != ans[j].ToString()[i])
+				{
+					ans.RemoveAt(j);
+					j--;
+					break;
+				}
+			}
+		}
+		if (ans.Count == 0)
+		{
+			yield return DoInteractionClick(_buttons[3]);
+			if (GetModuleType().Equals("AnagramsModule"))
+				ans = _component.GetValue<IList>("_solution");
+			else
+				ans.Add(_component.GetValue<string>("_solution"));
+			curr = "";
+		}
+		int start = curr.Length;
+		int ansIndex = Random.Range(0, ans.Count);
+		for (int j = start; j < 6; j++)
+			yield return DoInteractionClick(_buttons.Where(button => button.GetComponentInChildren<TextMesh>().text.ToLowerInvariant() == ans[ansIndex].ToString()[j].ToString().ToLowerInvariant()).ToList()[0]);
+		yield return DoInteractionClick(_buttons[7], 0);
+	}
+
+	private readonly object _component;
 	private readonly KMSelectable[] _buttons;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
@@ -66,15 +66,9 @@ public class AnagramsComponentSolver : ComponentSolver
 	{
 		yield return null;
 		string curr = _component.GetValue<TextMesh>("AnswerDisplay").text;
-		IList ans = new List<string>();
-		if (GetModuleType().Equals("AnagramsModule"))
-		{
-			IList temp = _component.GetValue<IList>("_solution");
-			for (int i = 0; i < temp.Count; i++)
-				ans.Add(temp[i]);
-		}
-		else
-			ans.Add(_component.GetValue<string>("_solution"));
+		List<string> ans = GetModuleType() == "AnagramsModule" ?
+			_component.GetValue<List<string>>("_solution") :
+			new List<string>() { _component.GetValue<string>("_solution") };
 		if (curr.Length > 6)
 		{
 			yield return DoInteractionClick(_buttons[3]);
@@ -84,7 +78,7 @@ public class AnagramsComponentSolver : ComponentSolver
 		{
 			for (int i = 0; i < curr.Length; i++)
 			{
-				if (curr[i] != ans[j].ToString()[i])
+				if (curr[i] != ans[j][i])
 				{
 					ans.RemoveAt(j);
 					j--;
@@ -95,8 +89,8 @@ public class AnagramsComponentSolver : ComponentSolver
 		if (ans.Count == 0)
 		{
 			yield return DoInteractionClick(_buttons[3]);
-			if (GetModuleType().Equals("AnagramsModule"))
-				ans = _component.GetValue<IList>("_solution");
+			if (GetModuleType() == "AnagramsModule")
+				ans = _component.GetValue<List<string>>("_solution");
 			else
 				ans.Add(_component.GetValue<string>("_solution"));
 			curr = "";
@@ -104,7 +98,7 @@ public class AnagramsComponentSolver : ComponentSolver
 		int start = curr.Length;
 		int ansIndex = Random.Range(0, ans.Count);
 		for (int j = start; j < 6; j++)
-			yield return DoInteractionClick(_buttons.Where(button => button.GetComponentInChildren<TextMesh>().text.ToLowerInvariant() == ans[ansIndex].ToString()[j].ToString().ToLowerInvariant()).ToList()[0]);
+			yield return DoInteractionClick(_buttons.Where(button => button.GetComponentInChildren<TextMesh>().text.ToLowerInvariant() == ans[ansIndex][j].ToString().ToLowerInvariant()).ToList()[0]);
 		yield return DoInteractionClick(_buttons[7], 0);
 	}
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/ConstellationsShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/ConstellationsShim.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections;
+
+public class ConstellationsShim : ComponentSolverShim
+{
+	public ConstellationsShim(TwitchModule module)
+		: base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_component = module.BombComponent.GetComponent(ComponentType);
+		_buttons = _component.GetValue<KMSelectable[]>("btns");
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		yield return DoInteractionClick(_buttons[_component.GetValue<int>("correctButton")]);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("constellationsScript", "constellations");
+
+	private readonly object _component;
+	private readonly KMSelectable[] _buttons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/GiantsDrinkShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/GiantsDrinkShim.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections;
+
+public class GiantsDrinkShim : ComponentSolverShim
+{
+	public GiantsDrinkShim(TwitchModule module)
+		: base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_component = module.BombComponent.GetComponent(ComponentType);
+		_buttons = new KMSelectable[] { _component.GetValue<KMSelectable>("btnLeft"), _component.GetValue<KMSelectable>("btnRight") };
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		int evenStrikes = _component.GetValue<int>("evenStrikes");
+		int oddStrikes = _component.GetValue<int>("oddStrikes");
+		if (Module.Bomb.Bomb.NumStrikes % 2 == 0)
+			yield return DoInteractionClick(_buttons[evenStrikes]);
+		else
+			yield return DoInteractionClick(_buttons[oddStrikes]);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("giantsDrinkScript", "giantsDrink");
+
+	private readonly object _component;
+	private readonly KMSelectable[] _buttons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/HeraldryShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/HeraldryShim.cs
@@ -31,19 +31,19 @@ public class HeraldryShim : ComponentSolverShim
 			sol = 4;
 		while (_component.GetValue<int>("currentCrest") + 1 < order[sol])
 		{
-			while (_component.GetValue<int>("animating") < 0) { if (sol == 1) yield return true; else yield return null; }
+			while (_component.GetValue<int>("animating") < 0) yield return sol == 1 ? true : (object) null;
 			if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
 				goto reCalc;
 			yield return DoInteractionClick(_pageTurn[1]);
 		}
 		while (_component.GetValue<int>("currentCrest") > order[sol])
 		{
-			while (_component.GetValue<int>("animating") > 0) { if (sol == 1) yield return true; else yield return null; }
+			while (_component.GetValue<int>("animating") > 0) yield return sol == 1 ? true : (object) null;
 			if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
 				goto reCalc;
 			yield return DoInteractionClick(_pageTurn[0]);
 		}
-		while (_component.GetValue<int>("animating") != 0) { if (sol == 1) yield return true; else yield return null; }
+		while (_component.GetValue<int>("animating") != 0) yield return sol == 1 ? true : (object) null;
 		if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
 			goto reCalc;
 		yield return DoInteractionClick(_crests[order[sol] % 2], 0);

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/HeraldryShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/HeraldryShim.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class HeraldryShim : ComponentSolverShim
+{
+	public HeraldryShim(TwitchModule module)
+		: base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_component = module.BombComponent.GetComponent(ComponentType);
+		_pageTurn = _component.GetValue<KMSelectable[]>("pageTurners");
+		_crests = _component.GetValue<KMSelectable[]>("crestSelectors");
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		List<int> order = _component.GetValue<List<int>>("order");
+		reCalc:
+		int curSolves = Module.Bomb.Bomb.GetSolvedComponentCount();
+		int sol = 5;
+		if (_component.GetValue<bool>("unicorn"))
+			sol = 1;
+		else if (curSolves % 4 == 0)
+			sol = 2;
+		else if (curSolves % 4 == 1)
+			sol = 3;
+		else if (curSolves % 4 == 2)
+			sol = 4;
+		while (_component.GetValue<int>("currentCrest") + 1 < order[sol])
+		{
+			while (_component.GetValue<int>("animating") < 0) { if (sol == 1) yield return true; else yield return null; }
+			if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
+				goto reCalc;
+			yield return DoInteractionClick(_pageTurn[1]);
+		}
+		while (_component.GetValue<int>("currentCrest") > order[sol])
+		{
+			while (_component.GetValue<int>("animating") > 0) { if (sol == 1) yield return true; else yield return null; }
+			if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
+				goto reCalc;
+			yield return DoInteractionClick(_pageTurn[0]);
+		}
+		while (_component.GetValue<int>("animating") != 0) { if (sol == 1) yield return true; else yield return null; }
+		if (curSolves != Module.Bomb.Bomb.GetSolvedComponentCount() && sol != 1)
+			goto reCalc;
+		yield return DoInteractionClick(_crests[order[sol] % 2], 0);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("Heraldry", "heraldry");
+
+	private readonly object _component;
+	private readonly KMSelectable[] _pageTurn;
+	private readonly KMSelectable[] _crests;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/IPhoneShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/IPhoneShim.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public class IPhoneShim : ComponentSolverShim
+{
+	public IPhoneShim(TwitchModule module)
+		: base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_component = module.BombComponent.GetComponent(ComponentType);
+		string[] numNames = { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
+		_subBtns = new KMSelectable[10];
+		for (int i = 0; i < 10; i++)
+			_subBtns[i] = _component.GetValue<KMSelectable>(numNames[i] + "SButton");
+		_settings = _component.GetValue<KMSelectable>("settings");
+		_home = _component.GetValue<KMSelectable>("home");
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		string enteredPIN = _component.GetValue<string>("enteredPIN");
+		string correctPIN = _component.GetValue<List<string>>("pinDigits").Join("");
+		int stage = _component.GetValue<int>("settingsStage");
+		for (int i = 0; i < stage - 1; i++)
+		{
+			if (correctPIN[i] != enteredPIN[i])
+				yield break;
+		}
+		if (!_subBtns[0].gameObject.activeSelf)
+		{
+			if (!_settings.gameObject.activeSelf)
+				yield return DoInteractionClick(_home);
+			yield return DoInteractionClick(_settings);
+		}
+		for (int i = stage; i <= 4; i++)
+			yield return DoInteractionClick(_subBtns[int.Parse(correctPIN[i - 1].ToString())]);
+	}
+
+	private static readonly Type ComponentType = ReflectionHelper.FindType("iPhoneScript", "iPhone");
+
+	private readonly object _component;
+	private readonly KMSelectable[] _subBtns;
+	private readonly KMSelectable _settings;
+	private readonly KMSelectable _home;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/PressXShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/PressXShim.cs
@@ -19,7 +19,7 @@ public class PressXShim : ComponentSolverShim
 	{
 		var match = Regex.Match(inputCommand.ToLowerInvariant(),
 			"^(?:press |tap )?(x|y|a|b)(?:(?: at| on)?([0-9: ]+))?$");
-		if (!match.Success || inputCommand.ToLowerInvariant().EqualsAny("press a", "press b", "press x", "press y")) yield break;
+		if (!match.Success || inputCommand.ToLowerInvariant().EqualsAny("press a", "press b", "press x", "press y", "a", "b", "x", "y")) yield break;
 		int index = "xyab".IndexOf(match.Groups[1].Value, StringComparison.Ordinal);
 		if (index < 0) yield break;
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/TaxReturnsShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/TaxReturnsShim.cs
@@ -14,6 +14,22 @@ public class TaxReturnsShim : ComponentSolverShim
 		_submitButton = _component.GetValue<KMSelectable>("submitBut");
 	}
 
+	protected override IEnumerator RespondToCommandShimmed(string inputCommand)
+	{
+		if (inputCommand.EqualsIgnoreCase("deadline"))
+		{
+			yield return null;
+			yield return DoInteractionClick(_toggleButton, 2);
+			yield return DoInteractionClick(_toggleButton, 0);
+		}
+		else
+		{
+			IEnumerator command = RespondToCommandUnshimmed(inputCommand);
+			while (command.MoveNext())
+				yield return command.Current;
+		}
+	}
+
 	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
 	{
 		yield return null;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/DossierModifierComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/DossierModifierComponentSolver.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+
+public class DossierModifierComponentSolver : ComponentSolver
+{
+	public DossierModifierComponentSolver(TwitchModule module) :
+		base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "!dossier help [View the commands for the dossier menu]");
+	}
+
+	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)
+	{
+		yield return null;
+		yield return "sendtochaterror Please use !dossier commands to interact with this module.";
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/ManualCodesComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/ManualCodesComponentSolver.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+
+public class ManualCodesComponentSolver : ReflectionComponentSolver
+{
+	public ManualCodesComponentSolver(TwitchModule module) :
+		base(module, "ManualCodeNeedy", "!{0} press <#/d/s> [Presses the specified button, where '#' is the digits 0-9, 'd' is delete and 's' is submit] | Presses can be chained, for ex: !{0} press 471s")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length != 2 || !command.StartsWith("press ")) yield break;
+		for (int i = 0; i < split[1].Length; i++)
+			if (!_order.Contains(split[1][i])) yield break;
+		if (!_component.GetValue<bool>("_isActive"))
+		{
+			yield return "sendtochaterror You can't interact with the module right now.";
+			yield break;
+		}
+
+		yield return null;
+		for (int i = 0; i < split[1].Length; i++)
+			yield return Click(Array.IndexOf(_order, split[1][i]));
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		var needyComponent = Module.BombComponent.GetComponent<NeedyComponent>();
+
+		while (true)
+		{
+			if (needyComponent.State != NeedyComponent.NeedyStateEnum.Running)
+			{
+				yield return true;
+				continue;
+			}
+
+			yield return null;
+			string ans = _component.GetValue<object>("_currentMetadata").GetValue<string>("LockCode");
+			while (!ans.StartsWith(_component.GetValue<string>("_currentCode")))
+				yield return Click(0);
+			int start = _component.GetValue<string>("_currentCode").Length;
+			for (int i = start; i < 3; i++)
+				yield return Click(Array.IndexOf(_order, ans[i]));
+			yield return Click(8);
+		}
+	}
+
+	private readonly char[] _order = new char[] { 'd', '1', '2', '3', '0', '4', '5', '6', 's', '7', '8', '9' };
+}

--- a/TwitchPlaysAssembly/Src/Helpers/CommandParser.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/CommandParser.cs
@@ -71,7 +71,7 @@ public class CommandParser
 		Assert(possibleInteger != null);
 
 		integer = (int) possibleInteger;
-		Assert(!(min != null && integer <= min) || (max != null && integer >= max));
+		Assert((min == null || integer >= min) && (max == null || integer <= max));
 
 		return this;
 	}

--- a/TwitchPlaysAssembly/Src/ModuleDistributions.cs
+++ b/TwitchPlaysAssembly/Src/ModuleDistributions.cs
@@ -18,6 +18,7 @@ public sealed class DistributionPool : ISerializable
 		Invalid,
 		AllSolvable,
 		AllNeedy,
+		AllModules,
 		Score,
 		Fixed,
 	}
@@ -73,6 +74,15 @@ public sealed class DistributionPool : ISerializable
 				case "ALL_NEEDY":
 					IsNeedy = true;
 					goto case "ALL_SOLVABLE";
+
+				// Examples:
+				//     ALL_MODULES (fair mix including needies)
+				case "ALL_MODULES":
+				case "ALLMODULES":
+					ComponentSource = (int) KMComponentPool.ComponentSource.Mods | (int) KMComponentPool.ComponentSource.Base;
+					Type = PoolType.AllModules;
+					ExtraData.Add(ComponentSource);
+					break;
 
 				// Examples:
 				//     SCORE, =10
@@ -231,6 +241,14 @@ public sealed class DistributionPool : ISerializable
 						? KMComponentPool.SpecialComponentTypeEnum.ALL_SOLVABLE
 						: KMComponentPool.SpecialComponentTypeEnum.ALL_NEEDY),
 					AllowedSources = (KMComponentPool.ComponentSource) ExtraData[0],
+					Count = count
+				};
+			case PoolType.AllModules:
+				List<KMGameInfo.KMModuleInfo> allModules = gi.GetAvailableModuleInfo().ToList();
+				return new KMComponentPool()
+				{
+					ComponentTypes = allModules.Where(x => !x.IsMod).Select(x => x.ModuleType).ToList(),
+					ModTypes = allModules.Where(x => x.IsMod).Select(x => x.ModuleId).ToList(),
 					Count = count
 				};
 			case PoolType.Score:

--- a/TwitchPlaysAssembly/Src/TwitchHoldable.cs
+++ b/TwitchPlaysAssembly/Src/TwitchHoldable.cs
@@ -450,7 +450,11 @@ public class TwitchHoldable
 		}
 		else if (CommandType == typeof(IRCConnectionManagerCommands))
 		{
-			HelpMessage = "sendtochat Disconnect the IRC from Twitch Plays with “!{0} disconnect”. For obvious reasons, only the streamer may do this.";
+			HelpMessage = "Disconnect the IRC from Twitch Plays with “!{0} disconnect”. For obvious reasons, only the streamer may do this.";
+		}
+		else if (CommandType == typeof(DossierCommands))
+		{
+			HelpMessage = "Move up in the dossier menu with “!{0} up”. Move down in the dossier menu 3 times with “!{0} down 3”. Select the current menu item with “!{0} select”. Select 2nd menu item from the top with “!{0} select 2”.";
 		}
 
 		if (string.IsNullOrEmpty(HelpMessage)) return false;
@@ -514,6 +518,8 @@ public class TwitchHoldable
 
 			if (CommandType == typeof(MissionBinderCommands))
 				MissionBinderCommands.InitializePage(Holdable);
+			else if (CommandType == typeof(DossierCommands))
+				DossierCommands.InitializePage(Holdable);
 		}
 		else if (frontFace != _heldFrontFace)
 		{

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -185,11 +185,59 @@ public class TwitchPlaySettingsData
 				new DistributionPool(1.0f, "ALL_SOLVABLE"),
 			}
 		}},
+		{ "fair+modneedy", new ModuleDistributions {
+			DisplayName = "Fair + Mod Needy",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(1.0f, "ALL_SOLVABLE"),
+				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY, MODS"),
+			},
+			MinModules = 2
+		}},
+		{ "fair+baseneedy", new ModuleDistributions {
+			DisplayName = "Fair + Base Needy",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(1.0f, "ALL_SOLVABLE"),
+				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY, BASE"),
+			},
+			MinModules = 2
+		}},
 		{ "fair+needy", new ModuleDistributions {
 			DisplayName = "Fair + Needy",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY, MODS"),
+				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
+			},
+			MinModules = 2
+		}},
+		{ "fair+2needies", new ModuleDistributions {
+			DisplayName = "Fair + 2 Needies",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(1.0f, "ALL_SOLVABLE"),
+				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
+				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
+			},
+			MinModules = 3
+		}},
+		{ "fair+needysometimes", new ModuleDistributions {
+			DisplayName = "Fair + Needy Sometimes",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(1.0f, "ALL_SOLVABLE"),
+				new DistributionPool(0.0f, "ALL_MODULES"),
+			},
+			MinModules = 2
+		}},
+		{ "fair+neediessometimes", new ModuleDistributions {
+			DisplayName = "Fair + Needies Sometimes",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.8f, "ALL_SOLVABLE"),
+				new DistributionPool(0.2f, "ALL_MODULES"),
+			},
+		}},
+		{ "chaos", new ModuleDistributions {
+			DisplayName = "Chaos",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.0f, "ALL_SOLVABLE"),
+				new DistributionPool(1.0f, "ALL_MODULES"),
 			},
 			MinModules = 2
 		}},

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -193,14 +193,6 @@ public class TwitchPlaySettingsData
 			},
 			MinModules = 2
 		}},
-		{ "fair+baseneedy", new ModuleDistributions {
-			DisplayName = "Fair + Base Needy",
-			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY, BASE"),
-			},
-			MinModules = 2
-		}},
 		{ "fair+needy", new ModuleDistributions {
 			DisplayName = "Fair + Needy",
 			Pools = new List<DistributionPool> {

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -30,8 +30,12 @@ public class TwitchPlaySettingsData
 	public bool EnableInteractiveMode = false;
 	public bool EnableAutomaticEdgework = true;
 	public bool EnableEdgeworkCommand = false;
+	public bool EnableBossAutoViewPin = true;
 	public bool EnableAutomaticCameraWall = true;
 	public bool EnableEdgeworkCameras = true;
+	public bool EnableModuleCameraLights = true;
+	public float ModuleCameraLightIntensity = 0.5f;
+	public bool EnableLastModuleZoom = true;
 	public string RepositoryUrl = "https://ktane.timwi.de/";
 	public string AnalyzerUrl = "https://ktane.timwi.de/More/Logfile%20Analyzer.html";
 	public bool EnableModeratorsCommand = true;
@@ -419,6 +423,7 @@ public class TwitchPlaySettingsData
 	public string UnsupportedNeedyWarning = "Found an unsupported Needy Component. Disabling it.";
 
 	public string TechSupportBlock = "@{1}, module {0} ({2}) has been interrupted by Tech Support and is completely inoperable.";
+	public string BackdoorHackingBlock = "@{1}, module {0} ({2}) is completely inoperable while you are being hacked.";
 
 	private static bool ValidateString(ref string input, string def, int parameters, bool forceUpdate = false)
 	{

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -351,6 +351,8 @@ public class TwitchPlaysService : MonoBehaviour
 				AddHoldable("ircmanager", holdable, commandType: typeof(IRCConnectionManagerCommands));
 			else if (holdable.GetComponent("ModSelectorTablet") != null)
 				AddHoldable("dmg", holdable, commandType: typeof(DMGCommands));
+			else if (holdable.GetComponent<MainMenu>())
+				AddHoldable("dossier", holdable, commandType: typeof(DossierCommands));
 			else
 			{
 				var id = holdable.name.ToLowerInvariant().Replace("(clone)", "");
@@ -525,7 +527,7 @@ public class TwitchPlaysService : MonoBehaviour
 			)
 		)
 		{
-			IRCConnection.SendMessage("That holdable is currently disabled and you cannot be interact with it.");
+			IRCConnection.SendMessage("That holdable is currently disabled and cannot be interacted with.");
 			return true;
 		}
 

--- a/TwitchPlaysAssembly/Src/UI/ModuleCameras.cs
+++ b/TwitchPlaysAssembly/Src/UI/ModuleCameras.cs
@@ -469,17 +469,21 @@ public class ModuleCameras : MonoBehaviour
 		TwitchPlaysService.Instance.StartCoroutine(UnviewModuleCoroutine(handle));
 	}
 
-	public List<ModuleCamera> GetCameras() { return _moduleCameras; }
-
-	public List<GameObject> GetEdgeworkCameras() { return edgeworkCameras; }
-
 	public void Hide() => SetCameraVisibility(false);
 
 	public void Show() => SetCameraVisibility(true);
 
-	public void HideNotes() => SetNotesVisibility(false);
+	public void SetCameraVisibility(bool visible)
+	{
+		foreach (ModuleCamera camera in _moduleCameras)
+			camera.CameraInstance.enabled = visible;
+	}
 
-	public void ShowNotes() => SetNotesVisibility(true);
+	public void SetEdgeworkCameraVisibility(bool visible)
+	{
+		foreach (GameObject camera in edgeworkCameras)
+			camera.SetActive(visible);
+	}
 
 	public void HideHud() => BombStatus.gameObject.SetActive(false);
 
@@ -663,6 +667,7 @@ public class ModuleCameras : MonoBehaviour
 	{
 		foreach (GameObject edgeworkCamera in edgeworkCameras)
 			Destroy(edgeworkCamera);
+		edgeworkCameras.Clear();
 
 		// Create widget cameras
 		var widgets = _currentBomb.Bomb.WidgetManager.GetWidgets();
@@ -894,25 +899,6 @@ public class ModuleCameras : MonoBehaviour
 
 		//Could not even borrow an unpinned camera, to allow the requested zoom to happen.
 		return -1;
-	}
-
-	private void SetCameraVisibility(bool visible)
-	{
-		foreach (ModuleCamera camera in _moduleCameras)
-			if (!visible || (camera.Module && camera.Module.CameraPriority > CameraPriority.Unviewed))
-				camera.CameraInstance.gameObject.SetActive(visible);
-	}
-
-	private void SetNotesVisibility(bool visible)
-	{
-		foreach (Text txt in NotesTexts)
-			txt.gameObject.SetActive(visible);
-		foreach (Image img in NotesTextBackgrounds)
-			img.gameObject.SetActive(visible);
-		foreach (Text txt in NotesTextIDs)
-			txt.gameObject.SetActive(visible);
-		foreach (Image img in NotesTextIDsBackgrounds)
-			img.gameObject.SetActive(visible);
 	}
 
 	private IEnumerator WaitForZoom(IEnumerator coroutine)

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -610,6 +610,7 @@ public class TwitchModule : MonoBehaviour
 				var setToLayer = _currentLayer ?? kvp.Value;
 				if (kvp.Key.gameObject.layer != setToLayer)
 					kvp.Key.gameObject.layer = setToLayer;
+
 				Camera cam = kvp.Key.gameObject.GetComponent<Camera>();
 				if (BombComponent.GetModuleDisplayName() == "Backdoor Hacking" && cam != null)
 					cam.cullingMask = (1 << setToLayer) | (1 << 31);

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -611,6 +611,7 @@ public class TwitchModule : MonoBehaviour
 				if (kvp.Key.gameObject.layer != setToLayer)
 					kvp.Key.gameObject.layer = setToLayer;
 
+				// Sets the camera layers of the cameras in Backdoor Hacking to the proper new TP layer to prevent blackscreening
 				Camera cam = kvp.Key.gameObject.GetComponent<Camera>();
 				if (BombComponent.GetModuleDisplayName() == "Backdoor Hacking" && cam != null)
 					cam.cullingMask = (1 << setToLayer) | (1 << 31);

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -180,6 +180,25 @@
             <syntax>run</syntax>
             <summary>Runs the dynamic mission generator with specific text. If enabled, players can only use this in Training Mode. Otherwise, only admins can access the DMG.</summary>
         </member>
+        <member name="T:DossierCommands">
+            <summary>Commands that can be used in the dossier menu.</summary>
+            <prefix>dossier </prefix>
+        </member>
+        <member name="M:DossierCommands.Select(FloatingHoldable)">
+            <name>Select</name>
+            <syntax>select</syntax>
+            <summary>Selects the currently highlighted item.</summary>
+        </member>
+        <member name="M:DossierCommands.SelectIndex(FloatingHoldable,System.Int32)">
+            <name>Select Index</name>
+            <syntax>select [index]</syntax>
+            <summary>Selects an item based on it's index on the menu.</summary>
+        </member>
+        <member name="M:DossierCommands.Navigate(System.String,System.Nullable{System.Int32})">
+            <name>Up / Down</name>
+            <syntax>up (amount)\ndown (amount)</syntax>
+            <summary>Moves up or down the menu by a number items.</summary>
+        </member>
         <member name="T:FreeplayCommands">
             <summary>Commands for the freeplay briefcase.</summary>
             <prefix>freeplay </prefix>


### PR DESCRIPTION
General Changes:
- Added support for dossier holdable
- Added and updated various pieces of code to get Backdoor Hacking to work, this includes hiding all elements of TP when getting hacked, preventing players not on Backdoor Hacking from using commands, and preventing TP from messing with the module's camera layering
- Changed around code for status light ID placement so Coinage's ID works the way the author intended (constantly moving on y-axis)
- Added settings to toggle automatically viewpinning bosses, enabling last module zoom, enabling lights on all cameras, and the intensity of the lights on all cameras
- Fixed HideHud and ShowHud not working at all
- Fixed last module camera zoom not unzooming once a new bomb is shown in Factory
- Added Voltage Meter to the edgework command
- A few typos in some messages
- Added ALL_MODULES pool which can pick for any module including needies, along with a few new run distributions that use this pool type

Module Changes:
- Fixed Press X exception in Shim
- Added a command to Tax Returns to view how much time is left before a strike
- Added a command to X & Y to allow for solving when an alarm clock is not present

New Component Solvers for:
- Dossier Modifier
- The Shaker
- Double Maze
- Logic Plumbing
- SI-HTS
- Triple Vision
- Backdoor Hacking
- Spelling Buzzed (ported from unpulled PR to module by tandyCake)
- Manual Codes (needy)

New Autosolvers for:
- Anagrams/Word Scramble
- Constellations
- Heraldry
- The iPhone
- The Giant's Drink