### PR TITLE
Add Automatically Updated Profiles

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -1222,6 +1222,10 @@ static class GlobalCommands
 		TwitchPlaySettings.LoadDataFromFile();
 		UserAccess.LoadAccessList();
 		yield return ComponentSolverFactory.LoadDefaultInformation(true);
+		if (TwitchPlaySettings.data.EnableAutoProfiles)
+		{
+			yield return ProfileHelper.LoadAutoProfiles();	
+		}
 
 		if (streamer)
 			UserAccess.AddUser(user, AccessLevel.Streamer);
@@ -1240,7 +1244,10 @@ static class GlobalCommands
 	public static IEnumerator ReloadScoreInfo(string user, bool isWhisper)
 	{
 		yield return ComponentSolverFactory.LoadDefaultInformation(true);
-
+		if (TwitchPlaySettings.data.EnableAutoProfiles)
+		{
+			yield return ProfileHelper.LoadAutoProfiles();	
+		}
 		IRCConnection.SendMessage("Score info reloaded", user, !isWhisper);
 	}
 

--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -1224,7 +1224,7 @@ static class GlobalCommands
 		yield return ComponentSolverFactory.LoadDefaultInformation(true);
 		if (TwitchPlaySettings.data.EnableAutoProfiles)
 		{
-			yield return ProfileHelper.LoadAutoProfiles();	
+			yield return ProfileHelper.LoadAutoProfiles();
 		}
 
 		if (streamer)
@@ -1246,7 +1246,7 @@ static class GlobalCommands
 		yield return ComponentSolverFactory.LoadDefaultInformation(true);
 		if (TwitchPlaySettings.data.EnableAutoProfiles)
 		{
-			yield return ProfileHelper.LoadAutoProfiles();	
+			yield return ProfileHelper.LoadAutoProfiles();
 		}
 		IRCConnection.SendMessage("Score info reloaded", user, !isWhisper);
 	}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -784,10 +784,12 @@ public static class ComponentSolverFactory
 		info.validCommands = regexList;
 	}
 
-	public static ModuleInformation GetDefaultInformation(string moduleType)
+	public static ModuleInformation GetDefaultInformation(string moduleType, bool addIfNotExist = true)
 	{
-		if (!DefaultModComponentSolverInformation.ContainsKey(moduleType))
+		if (!DefaultModComponentSolverInformation.ContainsKey(moduleType) && addIfNotExist)
 			AddDefaultModuleInformation(new ModuleInformation { moduleID = moduleType });
+		else if (!DefaultModComponentSolverInformation.ContainsKey(moduleType))
+			return null;
 		return DefaultModComponentSolverInformation[moduleType];
 	}
 

--- a/TwitchPlaysAssembly/Src/Helpers/CheckSupport.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/CheckSupport.cs
@@ -120,17 +120,7 @@ public static class CheckSupport
 		}
 
 		// Using the list of unsupported module IDs stored in unsupportedModules, make a Mod Selector profile.
-		string profilesPath = Path.Combine(Application.persistentDataPath, "ModProfiles");
-		if (Directory.Exists(profilesPath))
-		{
-			Dictionary<string, object> profileData = new Dictionary<string, object>()
-			{
-				{ "DisabledList", unsupportedModules },
-				{ "Operation", 1 }
-			};
-
-			File.WriteAllText(Path.Combine(profilesPath, "TP_Supported.json"), SettingsConverter.Serialize(profileData));
-		}
+		ProfileHelper.Write("TP_Supported", unsupportedModules);
 
 		alertProgressBar.localScale = Vector3.one;
 

--- a/TwitchPlaysAssembly/Src/Helpers/ProfileHelper.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/ProfileHelper.cs
@@ -61,8 +61,7 @@ static class ProfileHelper
 
 	public static IEnumerator LoadAutoProfiles()
 	{
-		yield return LoadData();
-
+		yield return null;
 		var modules = Modules.Where(x => (x.Type == "Needy" || x.Type == "Regular") && x.TwitchPlays != null).ToList();
 		var parsedNeedyModules = new List<Tuple<string, List<string>>>();
 		foreach (var needyModule in modules.Where(x => x.Type == "Needy"))
@@ -154,17 +153,18 @@ static class ProfileHelper
 
 				File.WriteAllText(Path.Combine(profilesPath, $"{profile.Key}.json"), SettingsConverter.Serialize(data));
 			}
+			
 			var bossProfile = new Dictionary<string, object>
 			{
 				{ "DisabledList", bossModules }, { "Operation", 1 }
 			};
+			
 			File.WriteAllText(Path.Combine(profilesPath, "NoBossModules.json"), SettingsConverter.Serialize(bossProfile));
-
 			foreach (var profile in needyProfiles.Where(x => !TwitchPlaySettings.data.ProfileWhitelist.Contains(x.Key)))
 				TwitchPlaySettings.data.ProfileWhitelist.Add(profile.Key);
+			
 			if (!TwitchPlaySettings.data.ProfileWhitelist.Contains("NoBossModules"))
 				TwitchPlaySettings.data.ProfileWhitelist.Add("NoBossModules");
-			TwitchPlaySettings.WriteDataToFile();
 
 			var profileWhitelist = TwitchPlaySettings.data.ProfileWhitelist.Where(x =>
 					new Regex(@"^No(?:(?:\d+\+?)|(?:StaticNeedies)|(?:TimeNeedies)|(?:OtherNeedies))$").Match(x)
@@ -179,11 +179,13 @@ static class ProfileHelper
 					TwitchPlaySettings.data.ProfileWhitelist.Remove(profile);
 				}
 			}
+			
 			TwitchPlaySettings.WriteDataToFile();
+			DebugHelper.Log("Auto Profiles loaded successfully!");
 		}
 		else
 		{
-			DebugHelper.LogError("Could not find ProfilesPath");
+			DebugHelper.LogError("Could not find ProfilesPath!");
 		}
 	}
 
@@ -225,7 +227,7 @@ static class ProfileHelper
 
 		return success;
 	}
-	
+
 	public static Profile GetProfile(string profilePath) => JsonConvert.DeserializeObject<Profile>(File.ReadAllText(profilePath));
 
 	public class Profile

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -53,6 +53,7 @@ public class TwitchPlaySettingsData
 	public int VoteCountdownTime = 60;
 	public bool EnableVoting = true;
 	public bool EnableVoteSolve = true;
+	public bool EnableAutoProfiles = true;
 	public Dictionary<VoteTypes, int> MinimumYesVotes = TwitchPlaySettings.GetVoteDict();
 	public float DynamicScoreMultiplier = 1;
 	public bool EnableTwitchPlayShims = true;

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -286,7 +286,7 @@ public class TwitchPlaysService : MonoBehaviour
 					initialLoad = true;
 					_coroutinesToStart.Enqueue(ComponentSolverFactory.LoadDefaultInformation(true));
 					_coroutinesToStart.Enqueue(Repository.LoadData());
-					_coroutinesToStart.Enqueue(ProfileHelper.LoadNeedyProfiles());
+					_coroutinesToStart.Enqueue(ProfileHelper.LoadAutoProfiles());
 					if (TwitchPlaySettings.data.TestModuleCompatibility && !TwitchPlaySettings.data.TwitchPlaysDebugEnabled)
 						_coroutinesToStart.Enqueue(CheckSupport.FindSupportedModules());
 				}

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -286,6 +286,7 @@ public class TwitchPlaysService : MonoBehaviour
 					initialLoad = true;
 					_coroutinesToStart.Enqueue(ComponentSolverFactory.LoadDefaultInformation(true));
 					_coroutinesToStart.Enqueue(Repository.LoadData());
+					_coroutinesToStart.Enqueue(ProfileHelper.LoadNeedyProfiles());
 					if (TwitchPlaySettings.data.TestModuleCompatibility && !TwitchPlaySettings.data.TwitchPlaysDebugEnabled)
 						_coroutinesToStart.Enqueue(CheckSupport.FindSupportedModules());
 				}

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -286,9 +286,10 @@ public class TwitchPlaysService : MonoBehaviour
 					initialLoad = true;
 					_coroutinesToStart.Enqueue(ComponentSolverFactory.LoadDefaultInformation(true));
 					_coroutinesToStart.Enqueue(Repository.LoadData());
-					_coroutinesToStart.Enqueue(ProfileHelper.LoadAutoProfiles());
 					if (TwitchPlaySettings.data.TestModuleCompatibility && !TwitchPlaySettings.data.TwitchPlaysDebugEnabled)
 						_coroutinesToStart.Enqueue(CheckSupport.FindSupportedModules());
+					if (TwitchPlaySettings.data.EnableAutoProfiles)
+						_coroutinesToStart.Enqueue(ProfileHelper.LoadAutoProfiles());
 				}
 
 				// Clear out the retry reward if we return to the setup room since the retry button doesn't return to setup.


### PR DESCRIPTION
This update adds a function that automatically adds, deletes, and modifies existing profiles.
This function supports the following 2 types of modules:

1. Modules using the Boss Module Manager will be automatically added to the NoBossModules profile.
2. Needy Modules will be sorted into profiles based on their score. The possible profiles are:
No0: Needy modules with a score of 0
No0+: Needy modules with a score between 0 and 1. (Exclusive, Exclusive).
No1: Needy modules with a score between 1 and 2. (Inclusive, Exclusive).
No2: Needy modules with a score between 2 and 3. (Inclusive, Exclusive).
No3 etc...

Additional profiles include:
NoStaticNeedies: For needies that have a static score that isn't 0.
NoTimeNeedies: For needies that are based on time.
NoOtherNeedies: For needies that don't fit any category,

_This feature can be enabled/disabled using the EnableAutoProfiles boolean in the settings file._