### PR TITLE
A bunch of updates

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -76,7 +76,8 @@ static class ModuleCommands
 
 	public static IEnumerator Show(TwitchModule module, object yield)
 	{
-		IEnumerator focusCoroutine = module.Bomb.Focus(module.Selectable, module.FocusDistance, module.FrontFace);
+		bool select = !module.BombComponent.GetModuleID().EqualsAny("lookLookAway");
+		IEnumerator focusCoroutine = module.Bomb.Focus(module.Selectable, module.FocusDistance, module.FrontFace, select);
 		while (focusCoroutine.MoveNext())
 			yield return focusCoroutine.Current;
 
@@ -84,10 +85,10 @@ static class ModuleCommands
 		yield return yield is float delay ? new WaitForSecondsWithCancel(delay, false, module.Solver) : yield;
 		if (CoroutineCanceller.ShouldCancel)
 		{
-			module.StartCoroutine(module.Bomb.Defocus(module.Selectable, module.FrontFace));
+			module.StartCoroutine(module.Bomb.Defocus(module.Selectable, module.FrontFace, select));
 			yield break;
 		}
-		IEnumerator defocusCoroutine = module.Bomb.Defocus(module.Selectable, module.FrontFace);
+		IEnumerator defocusCoroutine = module.Bomb.Defocus(module.Selectable, module.FrontFace, select);
 		while (defocusCoroutine.MoveNext())
 			yield return defocusCoroutine.Current;
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -93,6 +93,8 @@ public abstract class ComponentSolver
 			}
 		}
 
+		bool select = !Module.BombComponent.GetModuleID().EqualsAny("lookLookAway");
+
 		if (Solved != solved || _beforeStrikeCount != StrikeCount)
 		{
 			IRCConnection.SendMessageFormat("Please submit an issue at https://github.com/samfundev/KtaneTwitchPlays/issues regarding module !{0} ({1}) attempting to solve / strike prematurely.", Module.Code, Module.HeaderText);
@@ -105,13 +107,13 @@ public abstract class ComponentSolver
 
 			if (!TwitchPlaySettings.data.AnarchyMode)
 			{
-				IEnumerator focusDefocus = Module.Bomb.Focus(Module.Selectable, FocusDistance, FrontFace);
+				IEnumerator focusDefocus = Module.Bomb.Focus(Module.Selectable, FocusDistance, FrontFace, select);
 				while (focusDefocus.MoveNext())
 					yield return focusDefocus.Current;
 
 				yield return new WaitForSeconds(0.5f);
 
-				focusDefocus = Module.Bomb.Defocus(Module.Selectable, FrontFace);
+				focusDefocus = Module.Bomb.Defocus(Module.Selectable, FrontFace, select);
 				while (focusDefocus.MoveNext())
 					yield return focusDefocus.Current;
 
@@ -134,7 +136,7 @@ public abstract class ComponentSolver
 
 		AppreciateArtComponentSolver.ShowAppreciation(Module);
 
-		IEnumerator focusCoroutine = Module.Bomb.Focus(Module.Selectable, FocusDistance, FrontFace);
+		IEnumerator focusCoroutine = Module.Bomb.Focus(Module.Selectable, FocusDistance, FrontFace, select);
 		while (focusCoroutine.MoveNext())
 			yield return focusCoroutine.Current;
 
@@ -483,7 +485,7 @@ public abstract class ComponentSolver
 
 		AppreciateArtComponentSolver.HideAppreciation(Module);
 
-		IEnumerator defocusCoroutine = Module.Bomb.Defocus(Module.Selectable, FrontFace);
+		IEnumerator defocusCoroutine = Module.Bomb.Defocus(Module.Selectable, FrontFace, select);
 		while (defocusCoroutine.MoveNext())
 			yield return defocusCoroutine.Current;
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/CommandComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/CommandComponentSolver.cs
@@ -11,6 +11,11 @@ public abstract class CommandComponentSolver : ReflectionComponentSolver
 	{
 	}
 
+	protected CommandComponentSolver(TwitchModule module, string assemblyName, string componentString, string helpMessage) :
+		base(module, assemblyName, componentString, helpMessage)
+	{
+	}
+
 	public override IEnumerator Respond(string[] split, string command)
 	{
 		var methods = GetType()

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/CommandComponentSolverShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/CommandComponentSolverShim.cs
@@ -11,6 +11,11 @@ public abstract class CommandComponentSolverShim : ReflectionComponentSolverShim
 	{
 	}
 
+	protected CommandComponentSolverShim(TwitchModule module, string assemblyName, string componentString) :
+		base(module, assemblyName, componentString)
+	{
+	}
+
 	public override IEnumerator Respond(string[] split, string command)
 	{
 		var methods = GetType()

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -54,6 +54,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["SIHTS"] = module => new SIHTSComponentSolver(module);
 		ModComponentSolverCreators["doubleMaze"] = module => new DoubleMazeComponentSolver(module);
 		ModComponentSolverCreators["logicPlumbing"] = module => new LogicPlumbingComponentSolver(module);
+		ModComponentSolverCreators["flashingCube"] = module => new FlashingCubeComponentSolver(module);
 
 		//Asimir Modules
 		ModComponentSolverCreators["murder"] = module => new MurderComponentSolver(module);
@@ -148,6 +149,12 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["factoryCode"] = module => new FactoryCodeComponentSolver(module);
 		ModComponentSolverCreators["SpellingBuzzed"] = module => new SpellingBuzzedComponentSolver(module);
 		ModComponentSolverCreators["BackdoorHacking"] = module => new BackdoorHackingComponentSolver(module);
+		ModComponentSolverCreators["forget_fractal"] = module => new ForgetFractalComponentSolver(module);
+		ModComponentSolverCreators["NeedyPong"] = module => new PongComponentSolver(module);
+		ModComponentSolverCreators["needycrafting"] = module => new CraftingTableComponentSolver(module);
+		ModComponentSolverCreators["bigeggs"] = module => new PerspectiveEggsComponentSolver(module);
+		ModComponentSolverCreators["GL_nokiaModule"] = module => new NokiaComponentSolver(module);
+		ModComponentSolverCreators["lookLookAway"] = module => new LookLookAwayComponentSolver(module);
 
 		//ZekNikZ Modules
 		ModComponentSolverCreators["EdgeworkModule"] = module => new EdgeworkComponentSolver(module);
@@ -173,6 +180,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["TDSNeedyWires"] = module => new NeedyWiresComponentSolver(module);
 		ModComponentSolverCreators["TDSDossierModifier"] = module => new DossierModifierComponentSolver(module);
 		ModComponentSolverCreators["ManualCodes"] = module => new ManualCodesComponentSolver(module);
+		ModComponentSolverCreators["jackboxServerModule"] = module => new JackboxTVComponentSolver(module);
 
 		//Translated Modules
 		ModComponentSolverCreators["BigButtonTranslated"] = module => new TranslatedButtonComponentSolver(module);
@@ -266,6 +274,12 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["constellations"] = module => new ConstellationsShim(module);
 		ModComponentSolverCreators["giantsDrink"] = module => new GiantsDrinkShim(module);
 		ModComponentSolverCreators["heraldry"] = module => new HeraldryShim(module);
+		ModComponentSolverCreators["Color Decoding"] = module => new ColorDecodingShim(module);
+		ModComponentSolverCreators["TableMadness"] = module => new TableMadnessShim(module);
+		ModComponentSolverCreators["harmonySequence"] = module => new HarmonySequenceShim(module);
+		ModComponentSolverCreators["coopharmonySequence"] = module => new CoopHarmonySequenceShim(module);
+		ModComponentSolverCreators["safetySquare"] = module => new SafetySquareShim(module);
+		ModComponentSolverCreators["lgndEightPages"] = module => new EightPagesShim(module);
 
 		// Anti-troll shims - These are specifically meant to allow the troll commands to be disabled.
 		ModComponentSolverCreators["MazeV2"] = module => new AntiTrollShim(module, new Dictionary<string, string> { { "spinme", "Sorry, I am not going to waste time spinning every single pipe 360 degrees." } });
@@ -349,6 +363,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["SIHTS"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "SI-HTS" };
 		ModComponentSolverInformation["doubleMaze"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Double Maze" };
 		ModComponentSolverInformation["logicPlumbing"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Logic Plumbing" };
+		ModComponentSolverInformation["flashingCube"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Flashing Cube" };
 
 		//Mock Army
 		ModComponentSolverInformation["AnagramsModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Anagrams" };
@@ -434,6 +449,12 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["factoryCode"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Factory Code" };
 		ModComponentSolverInformation["SpellingBuzzed"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Spelling Buzzed" };
 		ModComponentSolverInformation["BackdoorHacking"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Backdoor Hacking" };
+		ModComponentSolverInformation["forget_fractal"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Forget Fractal", announceModule = true };
+		ModComponentSolverInformation["NeedyPong"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Pong" };
+		ModComponentSolverInformation["needycrafting"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "The Crafting Table" };
+		ModComponentSolverInformation["bigeggs"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "perspective eggs" };
+		ModComponentSolverInformation["GL_nokiaModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Nokia" };
+		ModComponentSolverInformation["lookLookAway"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Look, Look Away" };
 
 		//GoodHood
 		ModComponentSolverInformation["buttonOrder"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Button Order" };
@@ -478,6 +499,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["TDSNeedyWires"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Needy Wires" };
 		ModComponentSolverInformation["TDSDossierModifier"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Dossier Modifier" };
 		ModComponentSolverInformation["ManualCodes"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Manual Codes" };
+		ModComponentSolverInformation["jackboxServerModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Jackbox.TV", unclaimable = true };
 
 		//Translated Modules
 		ModComponentSolverInformation["BigButtonTranslated"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Big Button Translated" };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ReflectionComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ReflectionComponentSolver.cs
@@ -7,12 +7,18 @@ using UnityEngine;
 public abstract class ReflectionComponentSolver : ComponentSolver
 {
 	protected ReflectionComponentSolver(TwitchModule module, string componentTypeString, string helpMessage) :
+		this(module, null, componentTypeString, helpMessage)
+	{
+	}
+
+	protected ReflectionComponentSolver(TwitchModule module, string assemblyName, string componentTypeString, string helpMessage) :
 		base(module)
 	{
-		if (!componentTypes.ContainsKey(componentTypeString))
-			componentTypes[componentTypeString] = ReflectionHelper.FindType(componentTypeString);
+		string typeKey = $"{assemblyName}.{componentTypeString}";
+		if (!componentTypes.ContainsKey(typeKey))
+			componentTypes[typeKey] = ReflectionHelper.FindType(componentTypeString, assemblyName);
 
-		var componentType = componentTypes[componentTypeString];
+		var componentType = componentTypes[typeKey];
 
 		_component = module.BombComponent.GetComponent(componentType);
 		selectables = Module.BombComponent.GetComponent<KMSelectable>().Children;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ReflectionComponentSolverShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ReflectionComponentSolverShim.cs
@@ -4,7 +4,11 @@ public abstract class ReflectionComponentSolverShim : ReflectionComponentSolver
 {
 	protected ComponentSolver Unshimmed;
 
-	protected ReflectionComponentSolverShim(TwitchModule module, string componentTypeString) : base(module, componentTypeString, null)
+	protected ReflectionComponentSolverShim(TwitchModule module, string componentTypeString) : this(module, null, componentTypeString)
+	{
+	}
+
+	protected ReflectionComponentSolverShim(TwitchModule module, string assemblyName, string componentTypeString) : base(module, assemblyName, componentTypeString, null)
 	{
 		// Passing null to the BombCommander argument here because Unshimmed is only used to run RespondInternal(); we don’t want it to award strikes/solves etc. because this object already does that
 		Unshimmed = ComponentSolverFactory.CreateDefaultModComponentSolver(module, module.BombComponent.GetModuleID(), module.BombComponent.GetModuleDisplayName(), false);

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/FlashingCubeComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/FlashingCubeComponentSolver.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+
+public class FlashingCubeComponentSolver : ReflectionComponentSolver
+{
+	public FlashingCubeComponentSolver(TwitchModule module) :
+		base(module, "flashingCube", "!{0} press <top/left/front/right/bottom> [Presses the specified face of the cube] | Faces can be simplified to their first letter | Presses can be chained using spaces, commas, or semicolons")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length < 2 || !command.StartsWith("press ")) yield break;
+		for (int i = 1; i < split.Length; i++)
+		{
+			if (!split[i].EqualsAny("top", "t", "left", "l", "front", "f", "right", "r", "bottom", "b")) yield break;
+		}
+
+		yield return null;
+		for (int i = 1; i < split.Length; i++)
+		{
+			switch (split[i])
+			{
+				case "top":
+				case "t":
+					yield return Click(3);
+					break;
+				case "left":
+				case "l":
+					yield return Click(4);
+					break;
+				case "front":
+				case "f":
+					yield return Click(0);
+					break;
+				case "right":
+				case "r":
+					yield return Click(2);
+					break;
+				case "bottom":
+				case "b":
+					yield return Click(1);
+					break;
+			}
+		}
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/SIHTSComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Lone/SIHTSComponentSolver.cs
@@ -52,19 +52,30 @@ public class SIHTSComponentSolver : CommandComponentSolver
 		yield return null;
 
 		int tossType = _component.GetValue<int>("requiredTossType");
-		double tossValue = _component.GetValue<double>("requiredToss");
+		int tossValue = _component.GetValue<int>("requiredToss");
 		bool vegemite = _component.GetValue<bool>("vegemite");
-		if (tossType == 0 && !_component.GetValue<bool>("UHPressed"))
-			yield return Click(3);
-		else if (tossType == 1 && !_component.GetValue<bool>("FPressed"))
-			yield return Click(4);
-
-		if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("UH_noIntRot") % 1.0) == tossValue || ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("F_noIntRot") % 1.0) == tossValue)
-			yield return Click(0);
-		else if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("UH_decAccRot") % 1.0) == tossValue || ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("F_decAccRot") % 1.0) == tossValue)
-			yield return Click(vegemite ? 1 : 2);
-		else
-			yield return Click(vegemite ? 2 : 1);
+		if (tossType == 0)
+		{
+			if (!_component.GetValue<bool>("UHPressed"))
+				yield return Click(3);
+			if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("UH_noIntRot") % 1.0) == tossValue)
+				yield return Click(0);
+			else if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("UH_decAccRot") % 1.0) == tossValue)
+				yield return Click(vegemite ? 2 : 1);
+			else
+				yield return Click(vegemite ? 1 : 2);
+		}
+		else if (tossType == 1)
+		{
+			if (!_component.GetValue<bool>("FPressed"))
+				yield return Click(4);
+			if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("F_noIntRot") % 1.0) == tossValue)
+				yield return Click(0);
+			else if (ComponentType.CallMethod<double>("floatToEV", _component, _component.GetValue<double>("F_decAccRot") % 1.0) == tossValue)
+				yield return Click(vegemite ? 2 : 1);
+			else
+				yield return Click(vegemite ? 1 : 2);
+		}
 	}
 
 	private static readonly Type ComponentType = ReflectionHelper.FindType("SIHTS");

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/CraftingTableComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/CraftingTableComponentSolver.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections;
+
+public class CraftingTableComponentSolver : ReflectionComponentSolver
+{
+	public CraftingTableComponentSolver(TwitchModule module) :
+		base(module, "CraftingTableScript", "!{0} <button> [Presses the specified button (can chain with spaces)] | Valid buttons are stick, wood, cobble, iron, gold, diamond, reset and 1-9 for the cells of the crafting grid in reading order")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		for (int i = 0; i < split.Length; i++)
+		{
+			if (!split[i].EqualsAny("stick", "wood", "cobble", "cobblestone", "iron", "gold", "diamond", "reset", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+				yield break;
+		}
+		if (Module.BombComponent.GetComponent<NeedyComponent>().State != NeedyComponent.NeedyStateEnum.Running)
+		{
+			yield return "sendtochaterror You can't interact with the module right now.";
+			yield break;
+		}
+
+		yield return null;
+		for (int i = 0; i < split.Length; i++)
+		{
+			switch (split[i])
+			{
+				case "stick":
+					yield return Click(0);
+					break;
+				case "wood":
+					yield return Click(1);
+					break;
+				case "cobble":
+				case "cobblestone":
+					yield return Click(2);
+					break;
+				case "diamond":
+					yield return Click(3);
+					break;
+				case "gold":
+					yield return Click(4);
+					break;
+				case "iron":
+					yield return Click(5);
+					break;
+				case "reset":
+					yield return Click(15);
+					break;
+				default:
+					yield return Click(int.Parse(split[i]) + 5);
+					break;
+			}
+		}
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ForgetFractalComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/ForgetFractalComponentSolver.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections;
+using UnityEngine;
+
+public class ForgetFractalComponentSolver : ReflectionComponentSolver
+{
+	public ForgetFractalComponentSolver(TwitchModule module) :
+		base(module, "ForgetFractalModule", "!{0} screen/display [Presses the screen/display] | !{0} a2 g d3 ? [Sets the cell at A2 to green and D3 to ? (letter is column, number is row)]")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (command.EqualsAny("screen", "display"))
+		{
+			if (_component.GetValue<int>("_state") == 0 || _component.GetValue<int>("_state") == 1)
+			{
+				yield return "sendtochaterror The screen/display cannot be interacted with yet!";
+				yield break;
+			}
+			yield return null;
+			yield return Click(0, 0);
+		}
+		else if (split.Length % 2 == 0)
+		{
+			for (int i = 0; i < split.Length; i++)
+			{
+				if (i % 2 == 0)
+				{
+					if (split[i].Length != 2)
+						yield break;
+					if (!split[i][0].EqualsAny('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h') || !split[i][1].EqualsAny('1', '2', '3', '4'))
+						yield break;
+				}
+				else if (!split[i].EqualsAny("k", "r", "g", "b", "y", "m", "?"))
+					yield break;
+			}
+			if (_component.GetValue<int>("_state") != 3)
+			{
+				yield return "sendtochaterror You must be in submit mode to do this!";
+				yield break;
+			}
+			yield return null;
+			for (int i = 0; i < split.Length; i += 2)
+			{
+				int index = "1234".IndexOf(split[i][1]) * 8 + "abcdefgh".IndexOf(split[i][0]);
+				while (_component.GetValue<object[]>("_cells")[_btnPositions[index]].GetValue<Color>("Color") != _colors["krgbym?".IndexOf(split[i + 1][0])])
+					yield return Click(_btnPositions[index] + 1);
+			}
+		}
+	}
+
+	private readonly Color[] _colors = { Color.black, Color.red, Color.green, Color.blue, Color.yellow, Color.magenta, Color.cyan };
+	private readonly int[] _btnPositions = { 0, 1, 4, 5, 16, 17, 20, 21, 2, 3, 6, 7, 18, 19, 22, 23, 8, 9, 12, 13, 24, 25, 28, 29, 10, 11, 14, 15, 26, 27, 30, 31 };
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/LookLookAwayComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/LookLookAwayComponentSolver.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+
+public class LookLookAwayComponentSolver : ReflectionComponentSolver
+{
+	public LookLookAwayComponentSolver(TwitchModule module) :
+		base(module, "lookLookAwayScript", "!{0} submit <U/UR/R/DR/D/DL/L/UL> [Highlights the module and then unhighlights the module when the specified direction is displayed] | !{0} toggle [Presses the toggle button] | Direction submissions can be chained using spaces, commas, or semicolons")
+	{
+		ModuleSelectable = _component.GetValue<KMSelectable>("ModulePlate");
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (command.StartsWith("submit "))
+		{
+			string[] dirs = { "u", "ur", "r", "dr", "d", "dl", "l" };
+			for (int i = 1; i < split.Length; i++)
+			{
+				if (!dirs.Contains(split[i])) yield break;
+			}
+
+			yield return null;
+			for (int i = 1; i < split.Length; i++)
+			{
+				DoInteractionHighlight(ModuleSelectable);
+				yield return new WaitForSeconds(.05f);
+				int target = Array.IndexOf(dirs, split[i]);
+				while (_component.GetValue<int>("_currentDirection") != target) yield return null;
+				DoInteractionEnd(ModuleSelectable);
+				yield return new WaitForSeconds(.05f);
+				if (_component.GetValue<bool>("moduleSolved"))
+				{
+					yield return "solve";
+					break;
+				}
+			}
+		}
+		else if (command.Equals("toggle"))
+		{
+			yield return null;
+			yield return Click(0, 0);
+		}
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		IList current = _component.GetValue<IList>("_SubmissionSequence");
+		IList answer = _component.GetValue<IList>("_correctDirection");
+		int inputs = current.Count;
+		for (int i = 0; i < inputs; i++)
+		{
+			if (current[i] != answer[i])
+			{
+				yield return Click(0);
+				yield return Click(0);
+				inputs = 0;
+				break;
+			}
+		}
+		for (int i = inputs; i < 8; i++)
+		{
+			DoInteractionHighlight(ModuleSelectable);
+			yield return new WaitForSeconds(.05f);
+			while (_component.GetValue<int>("_currentDirection") != (int)answer[i]) yield return true;
+			DoInteractionEnd(ModuleSelectable);
+			yield return new WaitForSeconds(.05f);
+		}
+		while (!_component.GetValue<TextMesh>("ScreenArrow").text.Equals("<>")) yield return true;
+	}
+
+	private readonly KMSelectable ModuleSelectable;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/NokiaComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/NokiaComponentSolver.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections;
+using UnityEngine;
+
+public class NokiaComponentSolver : ReflectionComponentSolver
+{
+	public NokiaComponentSolver(TwitchModule module) :
+		base(module, "NokiaModule", "!{0} type <code> [Types in the specified code] | !{0} submit/send [Presses the green button] | !{0} clear/delete [Presses the red button]")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (command.EqualsAny("submit", "send"))
+		{
+			yield return null;
+			yield return Click(9, 0);
+		}
+		else if (command.EqualsAny("clear", "delete"))
+		{
+			yield return null;
+			yield return Click(11, 0);
+		}
+		else if (command.StartsWith("type "))
+		{
+			if (split.Length != 2) yield break;
+			if (!int.TryParse(split[1], out int check)) yield break;
+			if (check < 0) yield break;
+
+			yield return null;
+			for (int i = 0; i < split[1].Length; i++)
+			{
+				if (split[1][i] == '0')
+					yield return Click(10);
+				else
+					yield return Click(int.Parse(split[1][i].ToString()) - 1);
+			}
+		}
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+		string answer = _component.GetValue<int>("correctCode").ToString();
+		string input = _component.GetValue<TextMesh>("typingText").text;
+		if (!answer.StartsWith(input))
+		{
+			if (!input.Equals("Type in..."))
+				yield return Click(11);
+			input = "";
+		}
+		int start = input.Length;
+		for (int i = start; i < 6; i++)
+		{
+			if (answer[i] == '0')
+				yield return Click(10);
+			else
+				yield return Click(int.Parse(answer[i].ToString()) - 1);
+		}
+		yield return Click(9);
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/PerspectiveEggsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/PerspectiveEggsComponentSolver.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+public class PerspectiveEggsComponentSolver : ReflectionComponentSolver
+{
+	public PerspectiveEggsComponentSolver(TwitchModule module) :
+		base(module, "EggSaladScript", "!{0} press <red/eggshell/green/blue/yellow> [Presses the egg with the specified color] | Colors can be simplified to their first letter | Presses can be chained using spaces, commas, or semicolons")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length < 2 || !command.StartsWith("press ")) yield break;
+		for (int i = 1; i < split.Length; i++)
+		{
+			if (!split[i].EqualsAny("red", "r", "eggshell", "e", "green", "g", "blue", "b", "yellow", "y")) yield break;
+		}
+
+		yield return null;
+		IList comparer = _component.GetValue<IList>("Comparer");
+		for (int i = 1; i < split.Length; i++)
+		{
+			for (int j = 0; j < 5; j++)
+			{
+				if (((string) comparer[j])[0].Equals(split[i][0]))
+				{
+					yield return Click(j);
+					break;
+				}
+			}
+		}
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		Queue<int> positions = _component.GetValue<Queue<int>>("Object");
+		while (!_component.GetValue<bool>("Version"))
+			yield return Click(positions.Peek());
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/PongComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/PongComponentSolver.cs
@@ -1,0 +1,100 @@
+using System.Collections;
+using UnityEngine;
+
+public class PongComponentSolver : ReflectionComponentSolver
+{
+	public PongComponentSolver(TwitchModule module) :
+		base(module, "PongBackend", "NeedyPong143", "!{0} left/l/right/r <top/t/middle/m/bottom/b> [Sets the left or right paddle to the specified position on the screen] | On Twitch Plays the ball travels at half its normal speed")
+	{
+		Module.StartCoroutine(TPSpeedModifier());
+	}
+
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (split.Length != 2 || !split[0].EqualsAny("left", "l", "right", "r")) yield break;
+		if (!split[1].EqualsAny("top", "t", "middle", "m", "bottom", "b")) yield break;
+
+		yield return null;
+		if (split[0].FirstOrWhole("left") && split[1].FirstOrWhole("top"))
+		{
+			DoInteractionStart(selectables[0]);
+			while (_component.GetValue<float>("Paddle1Y") < 0.875f)
+				yield return null;
+			DoInteractionEnd(selectables[0]);
+		}
+		else if (split[0].FirstOrWhole("left") && split[1].FirstOrWhole("bottom"))
+		{
+			DoInteractionStart(selectables[1]);
+			while (_component.GetValue<float>("Paddle1Y") > 0.125f)
+				yield return null;
+			DoInteractionEnd(selectables[1]);
+		}
+		else if (split[0].FirstOrWhole("left") && split[1].FirstOrWhole("middle"))
+		{
+			if (_component.GetValue<float>("Paddle1Y") < 0.5f)
+			{
+				DoInteractionStart(selectables[0]);
+				while (_component.GetValue<float>("Paddle1Y") < 0.5f)
+					yield return null;
+				DoInteractionEnd(selectables[0]);
+			}
+			else
+			{
+				DoInteractionStart(selectables[1]);
+				while (_component.GetValue<float>("Paddle1Y") > 0.5f)
+					yield return null;
+				DoInteractionEnd(selectables[1]);
+			}
+		}
+		else if (split[0].FirstOrWhole("right") && split[1].FirstOrWhole("top"))
+		{
+			DoInteractionStart(selectables[2]);
+			while (_component.GetValue<float>("Paddle2Y") < 0.875f)
+				yield return null;
+			DoInteractionEnd(selectables[2]);
+		}
+		else if (split[0].FirstOrWhole("right") && split[1].FirstOrWhole("bottom"))
+		{
+			DoInteractionStart(selectables[3]);
+			while (_component.GetValue<float>("Paddle2Y") > 0.125f)
+				yield return null;
+			DoInteractionEnd(selectables[3]);
+		}
+		else
+		{
+			if (_component.GetValue<float>("Paddle2Y") < 0.5f)
+			{
+				DoInteractionStart(selectables[2]);
+				while (_component.GetValue<float>("Paddle2Y") < 0.5f)
+					yield return null;
+				DoInteractionEnd(selectables[2]);
+			}
+			else
+			{
+				DoInteractionStart(selectables[3]);
+				while (_component.GetValue<float>("Paddle2Y") > 0.5f)
+					yield return null;
+				DoInteractionEnd(selectables[3]);
+			}
+		}
+	}
+
+	private IEnumerator TPSpeedModifier()
+	{
+		bool setValue = true;
+		while (true)
+		{
+			yield return null;
+			if (setValue && _component.GetValue<bool>("playing"))
+			{
+				setValue = false;
+				_component.SetValue("BallVel", _component.GetValue<Vector2>("BallVel") * speedModifier);
+			}
+			else if (!setValue && !_component.GetValue<bool>("playing"))
+				setValue = true;
+		}
+	}
+
+	private readonly float speedModifier = 0.5f;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/CoopHarmonySequenceShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/CoopHarmonySequenceShim.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+
+public class CoopHarmonySequenceShim : ReflectionComponentSolverShim
+{
+	public CoopHarmonySequenceShim(TwitchModule module)
+		: base(module, "CoopHarmonySequenceScript", "coopharmonySequence")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		if (Unshimmed.ForcedSolveMethod == null) yield break;
+		var coroutine = (IEnumerator) Unshimmed.ForcedSolveMethod.Invoke(Unshimmed.CommandComponent, null);
+		while (coroutine.MoveNext())
+			yield return coroutine.Current;
+		while (_component.GetValue<bool>("harmonyRunning"))
+			yield return true;
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/HarmonySequenceShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/HarmonySequenceShim.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+
+public class HarmonySequenceShim : ReflectionComponentSolverShim
+{
+	public HarmonySequenceShim(TwitchModule module)
+		: base(module, "HarmonySequenceScript", "harmonySequence")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		if (Unshimmed.ForcedSolveMethod == null) yield break;
+		var coroutine = (IEnumerator) Unshimmed.ForcedSolveMethod.Invoke(Unshimmed.CommandComponent, null);
+		while (coroutine.MoveNext())
+			yield return coroutine.Current;
+		while (_component.GetValue<bool>("harmonyRunning"))
+			yield return true;
+	}
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/MysteryModuleShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Goofy/MysteryModuleShim.cs
@@ -2,12 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class MysteryModuleShim : ComponentSolverShim
+public class MysteryModuleShim : ReflectionComponentSolverShim
 {
 	public static readonly Dictionary<BombComponent, GameObject> CoveredModules = new Dictionary<BombComponent, GameObject>();
 
 	public MysteryModuleShim(TwitchModule module)
-		: base(module)
+		: base(module, "MysteryModuleScript")
 	{
 		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
 
@@ -18,18 +18,16 @@ public class MysteryModuleShim : ComponentSolverShim
 
 	IEnumerator WaitForMysteryModule()
 	{
-		var component = Module.BombComponent.GetComponent("MysteryModuleScript");
-
 		KMBombModule mystified;
 		do
 		{
-			mystified = component.GetValue<KMBombModule>("mystifiedModule");
+			mystified = _component.GetValue<KMBombModule>("mystifiedModule");
 			yield return null;
 		} while (mystified == null);
 
-		if (component.GetValue<bool>("failsolve"))
+		if (_component.GetValue<bool>("failsolve"))
 			yield break;
 
-		CoveredModules[mystified.GetComponent<BombComponent>()] = component.GetValue<GameObject>("Cover");
+		CoveredModules[mystified.GetComponent<BombComponent>()] = _component.GetValue<GameObject>("Cover");
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/LeGeND/EightPagesShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/LeGeND/EightPagesShim.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using UnityEngine;
 
 public class EightPagesShim : ComponentSolverShim
 {
@@ -16,17 +15,22 @@ public class EightPagesShim : ComponentSolverShim
 	{
 		var needyComponent = Module.BombComponent.GetComponent<NeedyComponent>();
 
+		if (needyComponent.State == NeedyComponent.NeedyStateEnum.Running && _component.GetValue<bool>("pickedUpPage") && _component.GetValue<bool>("Trapped"))
+		{
+			Module.BombComponent.GetComponent<KMNeedyModule>().HandlePass();
+			_component.CallMethod("HandleSolve");
+		}
+
 		while (true)
 		{
-			if (needyComponent.State != NeedyComponent.NeedyStateEnum.Running || _component.GetValue<bool>("pickedUpPage"))
+			if (needyComponent.State != NeedyComponent.NeedyStateEnum.Running || _component.GetValue<bool>("pickedUpPage") || _component.GetValue<bool>("Trapped"))
 			{
 				yield return true;
 				continue;
 			}
 
 			yield return null;
-			if (!_component.GetValue<bool>("pickedUpPage") && !_component.GetValue<bool>("Trapped"))
-				yield return DoInteractionClick(_page);
+			yield return DoInteractionClick(_page);
 		}
 	}
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/ColorDecodingShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/ColorDecodingShim.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+
+public class ColorDecodingShim : ReflectionComponentSolverShim
+{
+	public ColorDecodingShim(TwitchModule module)
+		: base(module, "ColorDecoding", "ColorDecoding")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_buttons = _component.GetValue<KMSelectable[]>("InputButtons");
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		IList constraint_tables = _component.GetValue<IList>("constraint_tables");
+		while (!Module.Solved)
+		{
+			List<int> valid_indexes = _component.GetValue<List<int>>("valid_indexes");
+			IDictionary dict = _component.GetValue<object>("display").CallMethod<IDictionary>("getConstraintHashMap");
+			int indicatorNum = _component.GetValue<object>("indicator").CallMethod<int>("getTableNum");
+
+			for (int i = 0; i < valid_indexes.Count; i++)
+			{
+				foreach (int key in dict.Keys)
+				{
+					if (!_component.GetValue<List<int>>("correctly_pressed_slots_stage").Contains(key) && dict[key].Equals(((IList) constraint_tables[indicatorNum])[valid_indexes[i]]))
+					{
+						yield return DoInteractionClick(_buttons[key]);
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	private readonly KMSelectable[] _buttons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SafetySquareShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SafetySquareShim.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+
+public class SafetySquareShim : ReflectionComponentSolverShim
+{
+	public SafetySquareShim(TwitchModule module)
+		: base(module, "SafetySquareScript", "safetySquare")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_buttons = _component.GetValue<KMSelectable[]>("buttons");
+		_hazardButtons = new KMSelectable[] { _component.GetValue<KMSelectable>("whiteButton"), _component.GetValue<KMSelectable>("yellowButton"), _component.GetValue<KMSelectable>("redButton"), _component.GetValue<KMSelectable>("blueButton") };
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		if (!_component.GetValue<bool>("stageTwo"))
+		{
+			int answer = _component.GetValue<int>("answer");
+			if (answer < 4)
+				yield return DoInteractionClick(_buttons[answer - 1]);
+			else if (answer == 4)
+				yield return DoInteractionClick(_buttons[answer]);
+			else
+				yield return DoInteractionClick(_buttons[answer - 2]);
+		}
+		string[] answers = new string[] { _component.GetValue<string>("ans1"), _component.GetValue<string>("ans2"), _component.GetValue<string>("ans3"), _component.GetValue<string>("ans4") };
+		int start = _component.GetValue<int>("stage") - 1;
+		for (int i = start; i < 4; i++)
+			yield return DoInteractionClick(_hazardButtons["WYRB".IndexOf(answers[i][0])]);
+	}
+
+	private readonly KMSelectable[] _buttons;
+	private readonly KMSelectable[] _hazardButtons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/TableMadnessShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/TableMadnessShim.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+public class TableMadnessShim : ReflectionComponentSolverShim
+{
+	public TableMadnessShim(TwitchModule module)
+		: base(module, "TableMadness", "TableMadness")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_buttons = _component.GetValue<KMSelectable[]>("buttons");
+	}
+
+	protected override IEnumerator ForcedSolveIEnumeratorShimmed()
+	{
+		yield return null;
+
+		TextMesh[] texts = _component.GetValue<TextMesh[]>("answertexts");
+		char[] letters = _component.GetValue<char[]>("letters");
+		char[] numbers = _component.GetValue<char[]>("numbers");
+		string solutionCoord = _component.CallMethod<string>("ConvertToCoordinate", _component.GetValue<int>("solution"));
+		int letInd = Array.IndexOf(letters, solutionCoord[0]);
+		int numInd = Array.IndexOf(numbers, solutionCoord[1]);
+		yield return SelectIndex(Array.IndexOf(letters, texts[0].text[0]), letInd, letters.Length, _buttons[1], _buttons[0]);
+		yield return SelectIndex(Array.IndexOf(numbers, texts[1].text[0]), numInd, numbers.Length, _buttons[3], _buttons[2]);
+		yield return DoInteractionClick(_buttons[4], 0);
+	}
+
+	private readonly KMSelectable[] _buttons;
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLBasicComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLBasicComponentSolver.cs
@@ -41,6 +41,11 @@ public class SQLBasicComponentSolver : ReflectionComponentSolver
 				if (!split[i].EqualsAny("a", "b", "c", "d", "e", "f", "g", "-"))
 					yield break;
 			}
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("selection1Button"), _component.GetValue<KMSelectable>("selection2Button"), _component.GetValue<KMSelectable>("selection3Button") };
@@ -60,6 +65,11 @@ public class SQLBasicComponentSolver : ReflectionComponentSolver
 					yield break;
 				if (!split[3].EqualsAny("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"))
 					yield break;
+				if (!_component.GetValue<bool>("isEditorMode"))
+				{
+					yield return "sendtochaterror You must be in the editor to do this!";
+					yield break;
+				}
 
 				yield return null;
 				KMSelectable[] changers = { _component.GetValue<KMSelectable>("where1LeftOperandButton"), _component.GetValue<KMSelectable>("where1OperatorButton"), _component.GetValue<KMSelectable>("where1RightOperandButton"), _component.GetValue<KMSelectable>("whereCombinationOperatorButton") };
@@ -79,6 +89,11 @@ public class SQLBasicComponentSolver : ReflectionComponentSolver
 					yield break;
 				if (!split[4].EqualsAny("and", "or"))
 					yield break;
+				if (!_component.GetValue<bool>("isEditorMode"))
+				{
+					yield return "sendtochaterror You must be in the editor to do this!";
+					yield break;
+				}
 
 				yield return null;
 				KMSelectable[] changers = { _component.GetValue<KMSelectable>("where1LeftOperandButton"), _component.GetValue<KMSelectable>("where1OperatorButton"), _component.GetValue<KMSelectable>("where1RightOperandButton"), _component.GetValue<KMSelectable>("whereCombinationOperatorButton"), _component.GetValue<KMSelectable>("where2LeftOperandButton"), _component.GetValue<KMSelectable>("where2OperatorButton"), _component.GetValue<KMSelectable>("where2RightOperandButton") };
@@ -96,6 +111,11 @@ public class SQLBasicComponentSolver : ReflectionComponentSolver
 				yield break;
 			if (!split[2].EqualsAny("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"))
 				yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("limitTakeButton"), _component.GetValue<KMSelectable>("limitSkipButton") };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLCruelComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLCruelComponentSolver.cs
@@ -51,6 +51,11 @@ public class SQLCruelComponentSolver : ReflectionComponentSolver
 				}
 			}
 			if (passed.Contains(false)) yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("selection1GroupButton"), _component.GetValue<KMSelectable>("selection2GroupButton"), _component.GetValue<KMSelectable>("selection3GroupButton") };
@@ -83,6 +88,11 @@ public class SQLCruelComponentSolver : ReflectionComponentSolver
 				yield break;
 			if (!split[3].EqualsAny("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"))
 				yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("where1LeftOperandButton"), _component.GetValue<KMSelectable>("where1OperatorButton"), _component.GetValue<KMSelectable>("where1RightOperandButton") };
@@ -97,6 +107,11 @@ public class SQLCruelComponentSolver : ReflectionComponentSolver
 			if (split.Length != 3) yield break;
 			if (!split[2].EqualsAny("a", "b", "c", "d", "e", "f", "g", "-"))
 				yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable changer = _component.GetValue<KMSelectable>("groupBy1Button");
@@ -110,6 +125,11 @@ public class SQLCruelComponentSolver : ReflectionComponentSolver
 				yield break;
 			if (!split[2].EqualsAny("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"))
 				yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("limitTakeButton"), _component.GetValue<KMSelectable>("limitSkipButton") };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLEvilComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheCrazyCodr/SQLEvilComponentSolver.cs
@@ -51,6 +51,11 @@ public class SQLEvilComponentSolver : ReflectionComponentSolver
 				}
 			}
 			if (passed.Contains(false)) yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable[] changers = { _component.GetValue<KMSelectable>("selection1GroupButton"), _component.GetValue<KMSelectable>("selection2GroupButton"), _component.GetValue<KMSelectable>("selection3GroupButton") };
@@ -79,6 +84,11 @@ public class SQLEvilComponentSolver : ReflectionComponentSolver
 			if (split.Length != 3) yield break;
 			if (!split[2].EqualsAny("a", "b", "c", "d", "e", "f", "g", "-"))
 				yield break;
+			if (!_component.GetValue<bool>("isEditorMode"))
+			{
+				yield return "sendtochaterror You must be in the editor to do this!";
+				yield break;
+			}
 
 			yield return null;
 			KMSelectable changer = _component.GetValue<KMSelectable>("groupBy1Button");

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/FreePasswordComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/FreePasswordComponentSolver.cs
@@ -1,29 +1,48 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 
 public class FreePasswordComponentSolver : ComponentSolver
 {
 	public FreePasswordComponentSolver(TwitchModule module) :
 		base(module)
 	{
-		string modType = GetModuleType();
-		ModInfo = ComponentSolverFactory.GetModuleInfo(modType, "!{0} submit [Presses the submit button]");
-		_submit = module.BombComponent.GetComponent<KMSelectable>().Children[modType == "FreePassword" ? 10 : 40];
+		_modType = GetModuleType();
+		ModInfo = ComponentSolverFactory.GetModuleInfo(_modType, _modType == "FreePassword" ? "!{0} submit [Presses the submit button] | !{0} WAHOO [Sets the display to \"WAHOO\"]" : "!{0} submit [Presses the submit button] | !{0} THEREEGGSONBOMBWAHOO [Sets the display to \"THEREEGGSONBOMBWAHOO\"]");
+		_buttons.AddRange(module.BombComponent.GetComponent<KMSelectable>().Children);
 	}
 
 	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)
 	{
-		if (!inputCommand.Equals("submit")) yield break;
-
-		yield return null;
-		yield return DoInteractionClick(_submit, 0);
+		if (inputCommand.ToLowerInvariant().Equals("submit"))
+		{
+			yield return null;
+			yield return DoInteractionClick(_buttons[_modType == "FreePassword" ? 10 : 40], 0);
+		}
+		else if (_modType == "FreePassword" && inputCommand.Length == 5)
+		{
+			yield return null;
+			int[] spinnerPos = Module.BombComponent.GetComponent(_modType).GetValue<int[]>("spinnerpositions");
+			for (int i = 0; i < 5; i++)
+				yield return SelectIndex(spinnerPos[i], Array.IndexOf(_spinnerChars, inputCommand.ToUpperInvariant()[i]), _spinnerChars.Length, _buttons[i + 5], _buttons[i]);
+		}
+		else if (_modType == "LargeFreePassword" && inputCommand.Length == 20)
+		{
+			yield return null;
+			int[] spinnerPos = Module.BombComponent.GetComponent(_modType).GetValue<int[]>("spinnerpositions");
+			for (int i = 0; i < 20; i++)
+				yield return SelectIndex(spinnerPos[i], Array.IndexOf(_spinnerChars, inputCommand.ToUpperInvariant()[i]), _spinnerChars.Length, _buttons[i > 9 ? i + 20 : i + 10], _buttons[i > 9 ? i + 10 : i]);
+		}
 	}
 
 	protected override IEnumerator ForcedSolveIEnumerator()
 	{
 		yield return null;
 
-		yield return DoInteractionClick(_submit);
+		yield return DoInteractionClick(_buttons[_modType == "FreePassword" ? 10 : 40]);
 	}
 
-	private readonly KMSelectable _submit;
+	private List<KMSelectable> _buttons = new List<KMSelectable>();
+	private readonly char[] _spinnerChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!?$%&@#'\"_+-=[{([{(^*<>.,`~\\/ ".ToCharArray();
+	private readonly string _modType;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/JackboxTVComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/JackboxTVComponentSolver.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+
+public class JackboxTVComponentSolver : ReflectionComponentSolver
+{
+	public JackboxTVComponentSolver(TwitchModule module) :
+		base(module, "jackboxServerModule", "!{0} s [Presses the solve button]")
+	{
+	}
+
+	public override IEnumerator Respond(string[] split, string command)
+	{
+		if (!command.Equals("s")) yield break;
+		if (!_component.GetValue<bool>("isSolved"))
+		{
+			yield return "sendtochaterror The solve button is not currently present!";
+			yield break;
+		}
+
+		yield return null;
+		yield return Click(0, 0);
+	}
+
+	protected override IEnumerator ForcedSolveIEnumerator()
+	{
+		yield return null;
+
+		if (_component.GetValue<bool>("isSolved"))
+			yield return Click(0);
+		else
+			yield return _component.CallMethod<IEnumerator>("WSSolve", "TP Autosolver");
+	}
+}


### PR DESCRIPTION
Added component solvers for:
- Flashing Cube
- The Crafting Table (Needy)
- Forget Fractal
- Look, Look Away (Special implementation, TP automatically highlights and unhighlights modules on most commands and even the last module zoom but the module inputs everytime the module is unhighlighted. To remedy this the feature is disabled if the module is Look, Look Away.)
- Nokia
- perspective eggs
- Pong (Needy)
- Jackbox.TV

Added shims to give autosolvers to:
- Color Decoding
- Harmony Sequence/Co-op Harmony Sequence
- Safety Square
- Table Madness

Fixed broken autosolvers for:
- Eight Pages
- SI-HTS

Fixed being able to set values on the SQL modules while still viewing the goal.

Added the ability to change the displays on Free Password and Large Free Password.