### PR TITLE
QoL: Always show when a mod is zoomed/superzoomed.

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -467,11 +467,7 @@ static class ModuleCommands
 				if (timed || !command) yields.Add(new WaitForSecondsWithCancel(delay, false, module.Solver));
 				IEnumerator toYield = yields.GetEnumerator();
 
-				IEnumerator routine = null;
-				if (show)
-				{
-					routine = Show(module, toYield);
-				}
+				IEnumerator routine = Show(module, toYield);
 				if (tilt)
 				{
 					routine = Tilt(module, toYield, groups["direction"].Value.ToLowerInvariant());


### PR DESCRIPTION
There is no disadvantage (such as time loss) and only provide better quality when (super)zooming at the correct side of the bomb.