### PR TITLE
Require "!# take" twice when a module has a command in the queue

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -229,6 +229,10 @@ static class ModuleCommands
 		else if (module.PlayerName == null)
 			IRCConnection.SendMessage(module.TryClaim(user).Message);
 
+		// Module has a queued command, likely a solve: forbid taking, that would interfere with the queue
+		else if (TwitchGame.Instance.CommandQueue.Any(c => c.Message.Text.StartsWith($"!{module.Code} ")))
+			IRCConnection.SendMessage($"@{user}, the module you are trying to take has a command in the queue.");
+
 		// Attempt to take over from another user
 		else
 		{

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -97,6 +97,7 @@ public class TwitchModule : MonoBehaviour
 
 	public Coroutine TakeInProgress;
 	public string TakeUser;
+	public bool TakeConfirmationShown; // Confirmation on taking a module that has a queued claim
 	public static List<string> ClaimedList = new List<string>();
 
 	public Action OnDestroyed;
@@ -552,6 +553,7 @@ public class TwitchModule : MonoBehaviour
 		SetBannerColor(ClaimedBackgroundColour);
 		PlayerName = userNickName;
 		CameraPriority |= CameraPriority.Claimed;
+		TakeConfirmationShown = false;
 	}
 
 	public void SetUnclaimed()


### PR DESCRIPTION
There's ~~no real reason~~ some reasons to allow a `!# take` on a module that already has a queued solve, but there's also some reasons it shouldn't. So ask for confirmation whenever someone tries to do that, by making them run the command again.