### PR TITLE
State of Aggregation: Redone TP handling

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StateOfAggregationComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/StateOfAggregationComponentSolver.cs
@@ -1,59 +1,74 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System;
 using UnityEngine;
 
 public class StateOfAggregationComponentSolver : ReflectionComponentSolver
 {
 	public StateOfAggregationComponentSolver(TwitchModule module) :
-		base(module, "StateOfAggregation", "!{0} cycle temp [Cycles through all temperatures in the temperature display] | !{0} submit <group> <temp> [Submits the specified chemical group and temperature]")
+		base(module, "StateOfAggregation", "Use '!{0} submit <chemical group>, <temperature>' to submit your answer. You may shorten chemical groups to the first few letters as long as they can be uniquely identified. To show all temperatures in the temperature display, use '!{0} cycle temp'.")
 	{
 	}
 
 	public override IEnumerator Respond(string[] split, string command)
 	{
-		if (command.StartsWith("submit "))
+		if (Regex.IsMatch(command, @"^cycle *(?:temps?)?$"))
 		{
-			if (split.Length < 3) yield break;
-			string[] groups = new string[_component.GetValue<string[]>("groups").Length];
-			for (int i = 0; i < groups.Length; i++)
-				groups[i] = _component.GetValue<string[]>("groups")[i].Replace(" ", "").ToLower();
-			string group = "";
-			for (int i = 1; i < split.Length - 1; i++)
-				group += split[i];
-			if (!groups.Contains(group)) yield break;
-
-			string[] temps = new string[_component.GetValue<string[]>("displayedTemps").Length];
-			string[] temps2 = new string[_component.GetValue<string[]>("displayedTemps").Length];
-			for (int i = 0; i < temps.Length; i++)
-			{
-				temps[i] = _component.GetValue<string[]>("displayedTemps")[i].ToLower();
-				temps2[i] = _component.GetValue<string[]>("displayedTemps")[i].ToLower().Replace("°", "");
-			}
-			if (!temps.Contains(split[split.Length - 1]) && !temps2.Contains(split[split.Length - 1])) yield break;
-
 			yield return null;
-			int current = _component.GetValue<int>("groupCounter");
-			yield return SelectIndex(current, Array.IndexOf(groups, group), groups.Length, selectables[2], selectables[0]);
 
-			current = _component.GetValue<int>("tempCounter");
-			if (temps.Contains(split[split.Length - 1]))
-				yield return SelectIndex(current, Array.IndexOf(temps, split[split.Length - 1]), temps.Length, selectables[5], selectables[3]);
-			else
-				yield return SelectIndex(current, Array.IndexOf(temps2, split[split.Length - 1]), temps2.Length, selectables[5], selectables[3]);
-
-			yield return Click(7, 0);
+			int cycleLength = _component.GetValue<string[]>("displayedTemps").Length;
+			for (int i = 0; i < cycleLength; i++)
+			{
+				yield return "trywaitcancel 2.0 the temperature cycle was cancelled";
+				yield return Click(5);
+			}
 		}
-		else if (command.Equals("cycle temp"))
+
+		Match mt;
+		if ((mt = Regex.Match(command, @"^submit +([a-zA-Z ]*)[, ]+(\-?[0-9\.]+)(?:(\u00B0?[cC]|\u2103)|(\u00B0?[fF]|\u2109)|([kK]))$")).Success)
 		{
+			// Capture group 1: Chemical name
+			string targetCG = mt.Groups[1].ToString().Replace(" ","").ToLower();
+			string[] allCGs = _component.GetValue<string[]>("groups");
+
+			List<string> matchedCGs = allCGs.Where(g => g.ToLower().Replace(" ","").StartsWith(targetCG)).ToList();
+			if (matchedCGs.Count() == 0)
+				yield return $"sendtochaterror!f No chemical group matches \"{mt.Groups[1].ToString()}\".";
+			else if (matchedCGs.Count() > 1)
+				yield return $"sendtochaterror!f Multiple chemical groups match \"{mt.Groups[1].ToString()}\": {matchedCGs.Join(", ")}";
+
+			// Capture group 2: Temperature
+			// Groups 3, 4, 5 detect Celsius, Farenheit, and Kelvin respectively.
+			string targetTemp;
+			string[] allTemps = _component.GetValue<string[]>("displayedTemps");
+
+			if (!float.TryParse(mt.Groups[2].ToString(), out _))
+				yield break; // Ignore invalid numbers, but don't actually use the float representation
+			if (mt.Groups[3].Success)      targetTemp = $"{mt.Groups[2]}\u00B0C";
+			else if (mt.Groups[4].Success) targetTemp = $"{mt.Groups[2]}\u00B0F";
+			else if (mt.Groups[5].Success) targetTemp = $"{mt.Groups[2]}K";
+			else                           yield break;
+
+			// We're executing the command at this point -- it's an unsubmittable penalty if the temperature is not present
 			yield return null;
-			string[] displayedTemps = _component.GetValue<string[]>("displayedTemps");
-			for (int i = 0; i < displayedTemps.Length; i++)
+
+			int currentIndex = _component.GetValue<int>("groupCounter");
+			int targetIndex = Array.IndexOf(allCGs, matchedCGs[0]);
+			yield return SelectIndex(currentIndex, targetIndex, allCGs.Length, selectables[2], selectables[0]);
+
+			currentIndex = _component.GetValue<int>("tempCounter");
+			targetIndex = Array.IndexOf(allTemps, targetTemp);
+			if (targetIndex == -1) // Not on the module
 			{
-				yield return "trycancel";
-				yield return new WaitForSeconds(2f);
-				yield return Click(5, 0);
+				for (int i = 0; i < allTemps.Length; ++i)
+					yield return Click(5);
+				yield return "unsubmittablepenalty";
+				yield break;
 			}
+			yield return SelectIndex(currentIndex, targetIndex, allTemps.Length, selectables[5], selectables[3]);
+			yield return Click(7);
 		}
 	}
 
@@ -61,6 +76,6 @@ public class StateOfAggregationComponentSolver : ReflectionComponentSolver
 	{
 		yield return null;
 
-		yield return RespondToCommandInternal($"submit {_component.GetValue<string[]>("groups")[_component.GetValue<int>("correctGroup")]} {_component.GetValue<string[]>("displayedTemps")[_component.GetValue<int>("correctTempIndex")]}");
+		yield return RespondToCommandInternal($"submit {_component.GetValue<string[]>("groups")[_component.GetValue<int>("correctGroup")]}, {_component.GetValue<string[]>("displayedTemps")[_component.GetValue<int>("correctTempIndex")]}");
 	}
 }


### PR DESCRIPTION
State of Aggregation has been the cause of some frustrations on TP lately, as it's unclear exactly what the module wants you to input, the help doesn't help clarify, and if you don't input exactly what it's looking for you just get the normal "invalid command" message.

This rewrites the entirety of the TP handling to be much more friendly, allowing shortened inputs or input with spaces, and allowing the degrees symbol to be omitted. The module is now clear about what exactly it's looking for (and will tell you precisely what your options are if you provide an input that happens to be ambiguous), although submitting a temperature that isn't on the module is now subject to an unsubmittable penalty (as usually this is a sign that you're not actually looking at the module's temperature list).