### PR TITLE
Additional minor QOL changes

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/PostGameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/PostGameCommands.cs
@@ -47,4 +47,14 @@ public static class PostGameCommands
 		// Therefore, just press the button a second time.
 		btn.Trigger();
 	}
+
+	public static IEnumerator AutoContinue()
+	{
+		if (TwitchPlaySettings.data.AutoReturnToSetupMinutes <= 0f)
+			yield break;
+		yield return new WaitForSeconds(TwitchPlaySettings.data.AutoReturnToSetupMinutes * 60f);
+
+		IRCConnection.SendMessage(TwitchPlaySettings.data.ReturningAutomatically);
+		yield return Continue();
+	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/BaseScore.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/BaseScore.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace TwitchPlays.ScoreMethods
 {
 	public class BaseScore : ScoreMethod
@@ -7,6 +9,8 @@ namespace TwitchPlays.ScoreMethods
 		}
 
 		public override float CalculateScore(string user) => Points;
+
+		public override float CalculateDifficulty() => Mathf.InverseLerp(4, 25, Points);
 
 		public override string Description => Points.Pluralize("base point");
 	}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/ClaimTime.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/ClaimTime.cs
@@ -47,6 +47,8 @@ namespace TwitchPlays.ScoreMethods
 			return score;
 		}
 
+		public override float CalculateDifficulty() => Mathf.InverseLerp(0f, 0.05f, Points);
+
 		public override string Description => Points.Pluralize("point") + " per second";
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/Deactivations.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/Deactivations.cs
@@ -57,6 +57,8 @@ namespace TwitchPlays.ScoreMethods
 			return score;
 		}
 
+		public override float CalculateDifficulty() => Mathf.InverseLerp(0.25f, 4.0f, Points);
+
 		public override string Description => Points.Pluralize("point") + " per deactivation";
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/PerAction.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/PerAction.cs
@@ -9,5 +9,7 @@ namespace TwitchPlays.ScoreMethods
 		public override string Description => Points.Pluralize("point") + " per action";
 
 		public override float CalculateScore(string user) => 0;
+
+		public override float CalculateDifficulty() => 0;
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/PerModule.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/PerModule.cs
@@ -31,6 +31,8 @@ namespace TwitchPlays.ScoreMethods
 			}
 		}
 
+		public override float CalculateDifficulty() => Mathf.InverseLerp(0.25f, 4.0f, Points);
+
 		public override string Description => Points.Pluralize("point") + " per module";
 	}
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/ScoreMethod.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ScoreMethods/ScoreMethod.cs
@@ -15,6 +15,8 @@ namespace TwitchPlays.ScoreMethods
 
 		public abstract float CalculateScore(string user);
 
+		public abstract float CalculateDifficulty();
+
 		public abstract string Description { get; }
 
 		public List<string> Players => Scores.Keys.ToList();

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -38,6 +38,7 @@ public class TwitchPlaySettingsData
 	public bool EnableLastModuleZoom = true;
 	public string RepositoryUrl = "https://ktane.timwi.de/";
 	public string AnalyzerUrl = "https://ktane.timwi.de/More/Logfile%20Analyzer.html";
+	public int AutoReturnToSetupMinutes = 0;
 	public bool EnableModeratorsCommand = true;
 	public bool EnableTrollCommands = false;
 	public bool EnableLetterCodes = false;
@@ -427,6 +428,7 @@ public class TwitchPlaySettingsData
 	public string TrainingModeCommandDisabled = "@{0}, Only authorized users may enable/disable Training Mode";
 	public string RunCommandDisabled = "@{0}, Only authorized users may use the !run command.";
 	public string ProfileCommandDisabled = "@{0}, profile management is currently disabled.";
+	public string ReturningAutomatically = "Automatically returning to the office due to inactivity.";
 	public string RetryInactive = "Retry is inactive. Returning to the office instead.";
 	public string RetryModeOrProfileChange = "There has been a change to profiles and/or game modes since the last bomb. Returning to the office instead.";
 
@@ -635,7 +637,9 @@ public class TwitchPlaySettingsData
 		valid &= ValidateString(ref TimeModeCommandDisabled, data.TimeModeCommandDisabled, 1);
 		valid &= ValidateString(ref VsModeCommandDisabled, data.VsModeCommandDisabled, 1);
 		valid &= ValidateString(ref ZenModeCommandDisabled, data.ZenModeCommandDisabled, 1);
+		valid &= ValidateString(ref ReturningAutomatically, data.ReturningAutomatically, 0);
 		valid &= ValidateString(ref RetryInactive, data.RetryInactive, 0);
+		valid &= ValidateString(ref RetryModeOrProfileChange, data.RetryModeOrProfileChange, 0);
 
 		valid &= ValidateString(ref AddedUserPower, data.AddedUserPower, 2, SettingsVersion < 1);
 		valid &= ValidateString(ref RemoveUserPower, data.RemoveUserPower, 2, SettingsVersion < 1);

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -303,6 +303,7 @@ public class TwitchPlaysService : MonoBehaviour
 				if (_leaderboardDisplay == null)
 					_leaderboardDisplay = Instantiate(TwitchLeaderboardPrefab);
 				Leaderboard.Instance.SaveDataToFile();
+				_coroutinesToStart.Enqueue(PostGameCommands.AutoContinue());
 				break;
 
 			case KMGameInfo.State.Transitioning:

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -212,12 +212,7 @@ public class TwitchModule : MonoBehaviour
 				var bar = _data.bar;
 				bar.transform.parent.gameObject.SetActive(TwitchPlaySettings.data.ShowModuleDifficulty && !ModInfo.unclaimable);
 
-				var value = Mathf.InverseLerp(4, 25, GetPoints<BaseScore>());
-				if (ScoreMethods.Any(method => method.GetType() == typeof(PerModule)))
-				{
-					value = Mathf.InverseLerp(0.25f, 4, GetPoints<PerModule>());
-				}
-
+				var value = ScoreMethods.ConvertAll<float>(method => method.CalculateDifficulty()).DefaultIfEmpty(0f).Max();
 				bar.transform.localScale = new Vector3(value, 1, 1);
 
 				Solver.Code = Code;


### PR DESCRIPTION
- `AutoReturnToSetupMinutes`: Strike likes leaving his stream in the setup room/office and not on the post game screen, this should help with that. Defaults to 0 (off).
- Difficulty bar calculations moved within ScoreMethods, and bar size is now calculated by polling every ScoreMethod a module has and taking the maximum value obtained. This gives time-based and deactivation-based scores non-empty difficulty bars as a result.
