### PR TITLE
Added a couple small (but important!) module shims

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -281,9 +281,11 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["coopharmonySequence"] = module => new CoopHarmonySequenceShim(module);
 		ModComponentSolverCreators["safetySquare"] = module => new SafetySquareShim(module);
 		ModComponentSolverCreators["lgndEightPages"] = module => new EightPagesShim(module);
+		ModComponentSolverCreators["KritLockpickMaze"] = module => new LockpickMazeShim(module);
 
 		// Anti-troll shims - These are specifically meant to allow the troll commands to be disabled.
 		ModComponentSolverCreators["MazeV2"] = module => new AntiTrollShim(module, new Dictionary<string, string> { { "spinme", "Sorry, I am not going to waste time spinning every single pipe 360 degrees." } });
+		ModComponentSolverCreators["danielDice"] = module => new AntiTrollShim(module, new Dictionary<string, string> { { "rdrts", "Sorry, the secret gambler's room is off limits to you." } });
 
 		//Module Information
 		//Information declared here will be used to generate ModuleInformation.json if it doesn't already exist, and will be overwritten by ModuleInformation.json if it does exist.

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/LockpickMazeShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/LockpickMazeShim.cs
@@ -1,0 +1,27 @@
+using System;
+
+public class LockpickMazeShim : ComponentSolverShim
+{
+	public LockpickMazeShim(TwitchModule module)
+		: base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		var componentType = ReflectionHelper.FindType("LockpickMazeModule", "KritLockpickMaze");
+		_component = module.BombComponent.GetComponent(componentType);
+
+		module.BombComponent.OnStrike += _ =>
+		{
+			// Time can expire in the middle of a movement command, and the pawn's location is not reset when that happens.
+			// So we should probably tell the person working on the module where the pawn ended up, hm?
+			if (_component.GetValue<int>("TimeLeft") == 0 && _component.GetValue<bool>("LockUnlocked") == true)
+			{
+				char col = (char)(_component.GetValue<int>("CurrentColumn") + 'A');
+				char row = (char)(_component.GetValue<int>("CurrentRow") + '1');
+				IRCConnection.SendMessage($"The pawn was at position {col}{row} when time expired on module {module.Code} (Lockpick Maze). It will remain there when the module is restarted.");
+			}
+			return false;
+		};
+	}
+
+	private readonly object _component;
+}


### PR DESCRIPTION
- Lockpick Maze: When time expires, the position of the pawn is not reset. This can (naturally) happen in the middle of a command. As such, we should tell chat where the pawn's location was when time expired. It also serves as a good reminder that the pawn doesn't move back to the original starting point, because this is something that frequently catches even experienced players off guard.
- Daniel Dice: AntiTrollShimmed `!rdrts`, as it locks the module into a state that is impossible to reliably solve (replaces predictable rules with true randomness and expects 30 consecutive correct high/low guesses). Even vote-solving wouldn't help, because the autosolver just picks randomly when in this mode.