### PR TITLE
Do not mention points in the solve message if the award is zero

### DIFF
--- a/Assets/Plugins/Managed/documentation.xml
+++ b/Assets/Plugins/Managed/documentation.xml
@@ -411,10 +411,10 @@
             <syntax>call (name)\ncallnow (name)</syntax>
             <summary>Calls a command from the queue. callnow skips the requirement set by Call Set. If (name) is specified calls a named command instead of the next command in the queue.</summary>
         </member>
-        <member name="M:GameCommands.CallAllQueuedCommands(System.String,System.Boolean)">
+        <member name="M:GameCommands.CallAllQueuedCommands(System.String,System.Boolean,System.Boolean)">
             <name>Call All</name>
-            <syntax>call all</syntax>
-            <summary>Calls all commands, including named ones.</summary>
+            <syntax>callall\ncallall force</syntax>
+            <summary>Calls all unnamed commands in the queue. If force is specified, named commands are included too.</summary>
         </member>
         <member name="M:GameCommands.CallSetCommand(System.String,System.Int32)">
             <name>Call Set</name>
@@ -677,7 +677,7 @@
             <name>Get Log</name>
             <syntax>lognow</syntax>
             <summary>Sends a message with the current log.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ShortURL(System.String,System.Boolean)">
             <name>Toggle Short URLs</name>
@@ -836,13 +836,13 @@
             <name>Run Raw</name>
             <syntax>runraw [mission id]</syntax>
             <summary>Runs a mission by it's full ID. Examples: mod_TwitchPlays_tpFMNHell or firsttime. Will softlock if required modules are mission or ID is incorrect.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.RunRawSeed(System.String,System.String)">
             <name>Run Raw Seed</name>
             <syntax>runrawseed [seed] [mission id]</syntax>
             <summary>The same as Run Raw but allows you to specify a seed.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ProfileHelp(System.String,System.Boolean)">
             <name>Profile Help</name>
@@ -879,6 +879,11 @@
             <name>Profile Create</name>
             <syntax>profile create [profile] [module]</syntax>
             <summary>Creates a new profile with a disabled module. [profile] must be a new profile name. [module] can be a partial module name or ID and can be surrounded with quotes if the name has a space.</summary>
+            <restriction>Admin</restriction>
+        </member>
+        <member name="M:GlobalCommands.ProfileDelete(System.String,System.Boolean,System.String)">
+            <syntax>profile delete [profile]</syntax>
+            <summary>Deletes a profile with the specified name.</summary>
             <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ProfileDisabledBy(System.String,System.String,System.Boolean)">
@@ -982,13 +987,13 @@
             <name>Mimic</name>
             <syntax>mimic [player] [command]</syntax>
             <summary>Makes it seem like another player ran the specified command. Only works with players of the same rank or lower.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.Skip">
             <name>Skip Command</name>
             <syntax>skipcommand</syntax>
             <summary>Forcibly skips the currently running command. It is only recommended to use this to skip a command that is stuck. This may cause issues and should be used with caution.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.RunCommandAs(System.String,System.String,System.String,System.String)">
             <name>Run as</name>

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -985,15 +985,26 @@ public abstract class ComponentSolver
 			if (OtherModes.VSModeOn)
 			{
 				if (!UnsupportedModule)
-					messageParts.Add(string.Format(TwitchPlaySettings.data.AwardVsSolve, Code, userNickName,
-						componentValue, headerText, HPDamage,
-						teamDamaged == OtherModes.Team.Evil ? "the evil team" : "the good team"));
-				else
+				{
+					if (componentValue != 0)
+						messageParts.Add(string.Format(TwitchPlaySettings.data.AwardVsSolve, Code, userNickName,
+							componentValue, headerText, HPDamage,
+							teamDamaged == OtherModes.Team.Evil ? "the evil team" : "the good team"));
+					else
+						messageParts.Add(string.Format(TwitchPlaySettings.data.AwardVsSolveNoPoints, Code, userNickName,
+							headerText, HPDamage,
+							teamDamaged == OtherModes.Team.Evil ? "the evil team" : "the good team"));
+				}
+				else if (componentValue != 0)
 					messageParts.Add(string.Format(TwitchPlaySettings.data.AwardSolve, Code, userNickName,
 						componentValue, headerText));
+				else
+					messageParts.Add(string.Format(TwitchPlaySettings.data.AwardSolveNoPoints, Code, userNickName, headerText));
 			}
-			else
+			else if (componentValue != 0)
 				messageParts.Add(string.Format(TwitchPlaySettings.data.AwardSolve, Code, userNickName, componentValue, headerText));
+			else
+				messageParts.Add(string.Format(TwitchPlaySettings.data.AwardSolveNoPoints, Code, userNickName, headerText));
 			string recordMessageTone = $"Module ID: {Code} | Player: {userNickName} | Module Name: {headerText} | Value: {componentValue}";
 			if (!OtherModes.TrainingModeOn) Leaderboard.Instance?.AddSolve(userNickName);
 			if (!UserAccess.HasAccess(userNickName, AccessLevel.NoPoints))

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -345,7 +345,9 @@ public class TwitchPlaySettingsData
 	public string HoldableCommandError = "@{1}, Holdable !{0} responded with the following error: {2}";
 
 	public string AwardSolve = "VoteYea {1} solved Module {0} ({3})! +{2} points. VoteYea";
+	public string AwardSolveNoPoints = "VoteYea {1} solved Module {0} ({2})! VoteYea";
 	public string AwardVsSolve = "VoteYea {1} solved Module {0} ({3})! +{2} points. -{4} HP from {5}. VoteYea";
+	public string AwardVsSolveNoPoints = "VoteYea {1} solved Module {0} ({2})! -{3} HP from {4}. VoteYea";
 	public string AwardStrike = "VoteNay Module {0} ({6}) got {1} strike{2}! {7} points from {4}{5} VoteNay";
 	public string AwardVsStrike = "VoteNay Module {0} ({6}) got {1} strike{2}! -{7} HP from {4}. {8} points from {9}{5} VoteNay";
 	public string AwardHoldableStrike = "VoteNay Holdable !{0} got {1} strike{2}! {3} points from {4}{5} VoteNay";
@@ -566,7 +568,9 @@ public class TwitchPlaySettingsData
 		valid &= ValidateString(ref HoldableCommandError, data.HoldableCommandError, 3);
 
 		valid &= ValidateString(ref AwardSolve, data.AwardSolve, 4);
+		valid &= ValidateString(ref AwardSolveNoPoints, data.AwardSolveNoPoints, 3);
 		valid &= ValidateString(ref AwardVsSolve, data.AwardVsSolve, 6);
+		valid &= ValidateString(ref AwardVsSolveNoPoints, data.AwardVsSolveNoPoints, 5);
 		valid &= ValidateString(ref AwardStrike, data.AwardStrike, 8);
 		valid &= ValidateString(ref AwardVsStrike, data.AwardVsStrike, 10);
 		valid &= ValidateString(ref AwardHoldableStrike, data.AwardHoldableStrike, 6);

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -411,10 +411,10 @@
             <syntax>call (name)\ncallnow (name)</syntax>
             <summary>Calls a command from the queue. callnow skips the requirement set by Call Set. If (name) is specified calls a named command instead of the next command in the queue.</summary>
         </member>
-        <member name="M:GameCommands.CallAllQueuedCommands(System.String,System.Boolean)">
+        <member name="M:GameCommands.CallAllQueuedCommands(System.String,System.Boolean,System.Boolean)">
             <name>Call All</name>
-            <syntax>call all</syntax>
-            <summary>Calls all commands, including named ones.</summary>
+            <syntax>callall\ncallall force</syntax>
+            <summary>Calls all unnamed commands in the queue. If force is specified, named commands are included too.</summary>
         </member>
         <member name="M:GameCommands.CallSetCommand(System.String,System.Int32)">
             <name>Call Set</name>
@@ -677,7 +677,7 @@
             <name>Get Log</name>
             <syntax>lognow</syntax>
             <summary>Sends a message with the current log.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ShortURL(System.String,System.Boolean)">
             <name>Toggle Short URLs</name>
@@ -836,13 +836,13 @@
             <name>Run Raw</name>
             <syntax>runraw [mission id]</syntax>
             <summary>Runs a mission by it's full ID. Examples: mod_TwitchPlays_tpFMNHell or firsttime. Will softlock if required modules are mission or ID is incorrect.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.RunRawSeed(System.String,System.String)">
             <name>Run Raw Seed</name>
             <syntax>runrawseed [seed] [mission id]</syntax>
             <summary>The same as Run Raw but allows you to specify a seed.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ProfileHelp(System.String,System.Boolean)">
             <name>Profile Help</name>
@@ -879,6 +879,11 @@
             <name>Profile Create</name>
             <syntax>profile create [profile] [module]</syntax>
             <summary>Creates a new profile with a disabled module. [profile] must be a new profile name. [module] can be a partial module name or ID and can be surrounded with quotes if the name has a space.</summary>
+            <restriction>Admin</restriction>
+        </member>
+        <member name="M:GlobalCommands.ProfileDelete(System.String,System.Boolean,System.String)">
+            <syntax>profile delete [profile]</syntax>
+            <summary>Deletes a profile with the specified name.</summary>
             <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.ProfileDisabledBy(System.String,System.String,System.Boolean)">
@@ -982,13 +987,13 @@
             <name>Mimic</name>
             <syntax>mimic [player] [command]</syntax>
             <summary>Makes it seem like another player ran the specified command. Only works with players of the same rank or lower.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.Skip">
             <name>Skip Command</name>
             <syntax>skipcommand</syntax>
             <summary>Forcibly skips the currently running command. It is only recommended to use this to skip a command that is stuck. This may cause issues and should be used with caution.</summary>
-            <restriction>SuperUser</restriction>
+            <restriction>Admin</restriction>
         </member>
         <member name="M:GlobalCommands.RunCommandAs(System.String,System.String,System.String,System.String)">
             <name>Run as</name>


### PR DESCRIPTION
With dynamic points, some modules (for example 0) have decided to award points entirely dynamically instead of having any static score component at all, this creates situations where messages are sent saying the player got +0 points. This PR cleans this up