### PR TITLE
set mimic back to SuperUser

### DIFF
--- a/Assets/Plugins/Managed/documentation.xml
+++ b/Assets/Plugins/Managed/documentation.xml
@@ -987,7 +987,7 @@
             <name>Mimic</name>
             <syntax>mimic [player] [command]</syntax>
             <summary>Makes it seem like another player ran the specified command. Only works with players of the same rank or lower.</summary>
-            <restriction>Admin</restriction>
+            <restriction>SuperUser</restriction>
         </member>
         <member name="M:GlobalCommands.Skip">
             <name>Skip Command</name>

--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -1465,8 +1465,8 @@ static class GlobalCommands
 	/// <name>Mimic</name>
 	/// <syntax>mimic [player] [command]</syntax>
 	/// <summary>Makes it seem like another player ran the specified command. Only works with players of the same rank or lower.</summary>
-	/// <restriction>Admin</restriction>
-	[Command(@"(?:issue|say|mimic)(?: ?commands?)?(?: ?as)? (\S+) (.+)", AccessLevel.Admin, AccessLevel.Admin)]
+	/// <restriction>SuperUser</restriction>
+	[Command(@"(?:issue|say|mimic)(?: ?commands?)?(?: ?as)? (\S+) (.+)", AccessLevel.SuperUser, AccessLevel.SuperUser)]
 	public static void Mimic([Group(1)] string targetPlayer, [Group(2)] string newMessage, IRCMessage message)
 	{
 		targetPlayer = targetPlayer.FormatUsername();

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -987,7 +987,7 @@
             <name>Mimic</name>
             <syntax>mimic [player] [command]</syntax>
             <summary>Makes it seem like another player ran the specified command. Only works with players of the same rank or lower.</summary>
-            <restriction>Admin</restriction>
+            <restriction>SuperUser</restriction>
         </member>
         <member name="M:GlobalCommands.Skip">
             <name>Skip Command</name>


### PR DESCRIPTION
mimic is an extremely powerful command, allowing the user to send a command as any other user, as such it should *only* be accessable to those who are most trusted, which is the superuser group