### PR TITLE
Distributions: Profile-based pools + code and settings cleanup

### DIFF
--- a/TwitchPlaysAssembly/Src/ModuleDistributions.cs
+++ b/TwitchPlaysAssembly/Src/ModuleDistributions.cs
@@ -221,7 +221,7 @@ public sealed class DistributionPool : ISerializable
 		PoolDefinition = def;
 	}
 
-	public DistributionPool(float weight, int reward, int time, string def)
+	public DistributionPool(float weight, string def, int reward, int time)
 	{
 		Weight = weight;
 		RewardPerModule = reward;

--- a/TwitchPlaysAssembly/Src/ModuleDistributions.cs
+++ b/TwitchPlaysAssembly/Src/ModuleDistributions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
@@ -15,15 +16,60 @@ public sealed class DistributionPool : ISerializable
 
 	public enum PoolType
 	{
+		// Default pool type or error, gives a warning if attempted to run
 		Invalid,
+
+		// Adds a pool of all enabled solvable modules
+		// Examples:
+		//     "AllSolvable" (fair mix)
+		//     "AllSolvable: Mods" (mods only)
 		AllSolvable,
+
+		// Adds a pool of all enabled needy modules
+		// Examples:
+		//     "AllNeedy" (fair mix)
+		//     "AllNeedy: Mods" (mods only)
 		AllNeedy,
+
+		// Adds a pool of all enabled modules, both solvable and needy
+		// Examples:
+		//     "AllModules" (fair mix including needies)
+		//     "AllModules: Mods" (as above, but mods only)
 		AllModules,
+
+		// Adds a pool containing all solvable modules that fit specific score constraints
+		// Ignores boss modules, or modules that don't have a base score
+		// TODO: Needs some way of accounting for dynamic scoring?
+		// Examples:
+		//     "Score: = 10" (modules with a base score of exactly 10)
+		//     "Score: < 7" (base score of 6 or less)
+		//     "Score: >= 7, <= 13" (base score between 7 and 13)
 		Score,
+
+		// Adds a pool containing all solvable modules enabled by an expert profile
+		// Examples:
+		//     EnabledBy: MyExpertProfile
+		//     EnabledBy: FooProfile, BarProfile (modules enabled by both)
+		ProfileEnables,
+
+		// Adds a pool containing all solvable modules disabled by a defuser profile
+		// Examples:
+		//     DisabledBy: NoBossModules
+		//     DisabledBy: NoColCipher, NoDream (modules disabled by both)
+		ProfileDisables,
+
+		// Adds a fixed pool of module IDs, works like a typical mission pool, meaning:
+		//  - The pool may contain duplicates to make one module more likely to show up
+		//  - All modules in a fixed pool must be enabled
+		// Examples:
+		//     Fixed: spwizTetris (just one module)
+		//     Fixed: brainf, HexiEvilFMN (pick between two)
+		//     Fixed: Wires, Wires, Wires, Wires, Venn (80% Wires, 20% Complicated Wires)
 		Fixed,
 	}
 	private PoolType Type;
-	private List<int> ExtraData;
+	private List<string> Arguments;
+	private Dictionary<string, int> PoolSettings;
 
 	private string __poolDef;
 	public string PoolDefinition
@@ -32,81 +78,71 @@ public sealed class DistributionPool : ISerializable
 		private set
 		{
 			__poolDef = value;
-
 			Type = PoolType.Invalid;
-			ExtraData = new List<int>();
+			Arguments = __poolDef.Split(new char[] {',', ':'}).Select(str => str.Trim()).ToList();
+			PoolSettings = new Dictionary<string, int>();
 
-			List<string> arguments = __poolDef.Split(',').Select(str => str.Trim().ToUpperInvariant()).ToList();
-			string mode = arguments[0];
-			arguments.RemoveAt(0);
+			string mode = Arguments[0].ToUpperInvariant();
+			Arguments.RemoveAt(0);
 
-			bool IsNeedy = false;
+			// Don't change Type until the end, so modes can immediately return to delcare a pool invalid
+			PoolType? FinalType = null;
+
 			switch (mode)
 			{
-				// Examples:
-				//     ALL_SOLVABLE (fair mix)
-				//     ALL_SOLVABLE, MODS (mods only)
 				case "SOLVABLE":
 				case "ALLSOLVABLE":
 				case "ALL_SOLVABLE":
+					FinalType = FinalType ?? PoolType.AllSolvable;
+
 					int ComponentSource = (int) KMComponentPool.ComponentSource.Mods | (int) KMComponentPool.ComponentSource.Base;
-					if (arguments.Count == 1)
+					if (Arguments.Count == 1)
 					{
-						if (arguments[0].Equals("MODS"))
+						if (Arguments[0].ToUpperInvariant().Equals("MODS"))
 							ComponentSource = (int) KMComponentPool.ComponentSource.Mods;
-						else if (arguments[0].Equals("BASE"))
+						else if (Arguments[0].ToUpperInvariant().Equals("BASE"))
 							ComponentSource = (int) KMComponentPool.ComponentSource.Base;
 						else
 							return; // Not valid
 					}
-					else if (arguments.Count >= 2)
+					else if (Arguments.Count >= 2)
 						return; // Also not valid
 
-					Type = IsNeedy ? PoolType.AllNeedy : PoolType.AllSolvable;
-					ExtraData.Add(ComponentSource);
+					PoolSettings["Component Source"] = ComponentSource;
 					break;
 
-				// Examples:
-				//     ALL_NEEDY (fair mix)
-				//     ALL_NEEDY, MODS (mods only)
 				case "NEEDY":
 				case "ALLNEEDY":
 				case "ALL_NEEDY":
-					IsNeedy = true;
+					FinalType = PoolType.AllNeedy;
 					goto case "ALL_SOLVABLE";
 
-				// Examples:
-				//     ALL_MODULES (fair mix including needies)
-				case "ALL_MODULES":
 				case "ALLMODULES":
-					ComponentSource = (int) KMComponentPool.ComponentSource.Mods | (int) KMComponentPool.ComponentSource.Base;
-					Type = PoolType.AllModules;
-					ExtraData.Add(ComponentSource);
-					break;
+				case "ALL_MODULES":
+					FinalType = PoolType.AllModules;
+					goto case "ALL_SOLVABLE";
 
-				// Examples:
-				//     SCORE, =10
-				//     SCORE, <7
-				//     SCORE, >=7, <=13
 				case "SCORE":
+					FinalType = PoolType.Score;
+
 					Match mt;
 					int ScoreMin = int.MinValue, ScoreMax = int.MaxValue;
-					if (arguments.Count == 0 || arguments.Count > 2)
+					if (Arguments.Count == 0 || Arguments.Count > 2)
 						return; // Not valid
 
-					if (arguments.Count == 1 && (mt = Regex.Match(arguments[0], @"^= *(\d+)$")).Success)
+					if (Arguments.Count == 1 && (mt = Regex.Match(Arguments[0], @"^= *(\d+)$")).Success)
 					{
 						if (!int.TryParse(mt.Groups[1].ToString(), out ScoreMin))
-							return;
+							return; // Invalid number - unlikely, but possible
 						ScoreMax = ScoreMin;
 					}
 					else
-						foreach (string arg in arguments)
+						foreach (string arg in Arguments)
 						{
 							if ((mt = Regex.Match(arg, @"^([<>]=?) *(\d+)$")).Success)
 							{
 								if (!int.TryParse(mt.Groups[2].ToString(), out int temp))
-									return;
+									return; // Invalid number - unlikely, but possible
 								switch (mt.Groups[1].ToString())
 								{
 									case ">": ScoreMin = temp + 1; break;
@@ -117,28 +153,36 @@ public sealed class DistributionPool : ISerializable
 								}
 							}
 							else
-								return;
+								return; // Invalid - bad form
 						}
 
-					if (arguments.Count == 2 && (ScoreMin == int.MinValue || ScoreMax == int.MaxValue))
-						return;
+					if (Arguments.Count == 2 && (ScoreMin == int.MinValue || ScoreMax == int.MaxValue))
+						return; // Don't allow conflicting constraints like "< 10, < 50"
 
-					Type = PoolType.Score;
-					ExtraData.Add(ScoreMin);
-					ExtraData.Add(ScoreMax);
+					PoolSettings["Score Min"] = ScoreMin;
+					PoolSettings["Score Max"] = ScoreMax;
 					break;
 
-				// Examples:
-				//     FIXED, spwizTetris
-				//     FIXED, brainf, HexiEvilFMN
-				case "FIXED":
-					if (arguments.Count == 0)
-						return; // Not valid
+				case "ENABLEDBY":
+				case "ENABLED_BY":
+				case "PROFILE_ENABLED_BY":
+					FinalType = PoolType.ProfileEnables;
+					goto case "FIXED";
 
-					// We don't really get to do much, since we're given the entire pool.
-					Type = PoolType.Fixed;
+				case "DISABLEDBY":
+				case "DISABLED_BY":
+				case "PROFILE_DISABLED_BY":
+					FinalType = PoolType.ProfileDisables;
+					goto case "FIXED";
+
+				case "FIXED":
+					FinalType = FinalType ?? PoolType.Fixed;
+					if (Arguments.Count == 0)
+						return; // Not valid
+					// All cases here use the argument list when generating pools
 					break;
 			}
+			Type = FinalType ?? PoolType.Invalid;
 		}
 	}
 
@@ -196,29 +240,35 @@ public sealed class DistributionPool : ISerializable
 			throw new ArgumentOutOfRangeException("Count cannot be negative");
 
 		KMGameInfo gi = TwitchPlaysService.Instance.GetComponent<KMGameInfo>();
+		List<KMGameInfo.KMModuleInfo> AllModules = gi.GetAvailableModuleInfo().ToList();
+
+		// Place a list of KMModuleInfos into this variable, and they'll be added into a ComponentPool at the end.
+		List<KMGameInfo.KMModuleInfo> ModulePool = null;
 
 		switch (Type)
 		{
 			case PoolType.AllSolvable:
 			case PoolType.AllNeedy:
+				// Use the game's built in ALL_SOLVABLE/ALL_NEEDY types.
 				return new KMComponentPool()
 				{
 					SpecialComponentType = (Type == PoolType.AllSolvable
 						? KMComponentPool.SpecialComponentTypeEnum.ALL_SOLVABLE
 						: KMComponentPool.SpecialComponentTypeEnum.ALL_NEEDY),
-					AllowedSources = (KMComponentPool.ComponentSource) ExtraData[0],
+					AllowedSources = (KMComponentPool.ComponentSource) PoolSettings["Component Source"],
 					Count = count
 				};
+	
 			case PoolType.AllModules:
-				List<KMGameInfo.KMModuleInfo> allModules = gi.GetAvailableModuleInfo().ToList();
-				return new KMComponentPool()
-				{
-					ComponentTypes = allModules.Where(x => !x.IsMod).Select(x => x.ModuleType).ToList(),
-					ModTypes = allModules.Where(x => x.IsMod).Select(x => x.ModuleId).ToList(),
-					Count = count
-				};
+				// This one doesn't exist in the game, so we have to make it ourselves.
+				ModulePool = AllModules.Where(Module => {
+					if (Module.IsMod) return (PoolSettings["Component Source"] & (int)KMComponentPool.ComponentSource.Mods) != 0;
+					else              return (PoolSettings["Component Source"] & (int)KMComponentPool.ComponentSource.Base) != 0;
+				}).ToList();
+				break;
+
 			case PoolType.Score:
-				List<KMGameInfo.KMModuleInfo> scoredModules = gi.GetAvailableModuleInfo().Where(x =>
+				ModulePool = AllModules.Where(x =>
 				{
 					if (x.IsNeedy)
 						return false;
@@ -229,46 +279,54 @@ public sealed class DistributionPool : ISerializable
 						return false;
 
 					var baseScore = baseMethod.Points;
-					return baseScore >= ExtraData[0] && baseScore <= ExtraData[1];
+					return baseScore >= PoolSettings["Score Min"] && baseScore <= PoolSettings["Score Max"];
 				}).ToList();
+				break;
 
-				if (scoredModules.Count == 0)
-					throw new InvalidOperationException("There are no enabled modules that fit the score requirements.");
+			case PoolType.ProfileEnables:
+			case PoolType.ProfileDisables:
+				HashSet<string> relevantMods = new HashSet<string>();
 
-				return new KMComponentPool()
+				foreach (string ProfileName in Arguments)
 				{
-					ComponentTypes = scoredModules.Where(x => !x.IsMod).Select(x => x.ModuleType).ToList(),
-					ModTypes = scoredModules.Where(x => x.IsMod).Select(x => x.ModuleId).ToList(),
-					Count = count
-				};
-			case PoolType.Fixed:
-				List<string> moduleIDs = __poolDef.Split(',').Select(str => str.Trim()).ToList();
-				moduleIDs.RemoveAt(0); // Remove "FIXED"
+					ProfileHelper.Profile data;
+					string profilePath = Path.Combine(ProfileHelper.ProfileFolder, ProfileName + ".json");
+					try { data = ProfileHelper.GetProfile(profilePath); }
+					catch (FileNotFoundException) { throw new InvalidOperationException($"Profile {ProfileName} doesn't exist."); }
 
-				List<string> availableMods = gi.GetAvailableModuleInfo().Where(x => x.IsMod).Select(x => x.ModuleId).ToList();
-				List<KMComponentPool.ComponentTypeEnum> poolVanillas = new List<KMComponentPool.ComponentTypeEnum>();
-				List<string> poolMods = new List<string>();
-
-				foreach (string module in moduleIDs)
-				{
-					if (Enum.GetNames(typeof(KMComponentPool.ComponentTypeEnum)).Contains(module))
-						poolVanillas.Add((KMComponentPool.ComponentTypeEnum) Enum.Parse(typeof(KMComponentPool.ComponentTypeEnum), module));
-					else
-					{
-						if (!availableMods.Contains(module))
-							throw new InvalidOperationException($"This distribution contains a fixed pool, and at least one of the modules in that pool ({module}) is not enabled.");
-						poolMods.Add(module);
-					}
+					relevantMods.UnionWith((Type == PoolType.ProfileEnables) ? data.EnabledList : data.DisabledList);
 				}
-				return new KMComponentPool()
-				{
-					ComponentTypes = poolVanillas,
-					ModTypes = poolMods,
-					Count = count
-				};
+
+				// Profiles cannot contain info about vanilla modules, so a profile pool is always mods only.
+				ModulePool = AllModules.Where(x => x.IsMod && !x.IsNeedy && relevantMods.Contains(x.ModuleId)).ToList();
+				break;
+
+			case PoolType.Fixed:
+				// We treat a fixed pool like a regualar pool in a mission; i.e. we allow duplicates for the purposes of
+				// making some modules more likely than others, and if any module is missing then we bail out.
+				Dictionary<string, KMGameInfo.KMModuleInfo> reverseLookup = AllModules.ToDictionary(x => {
+					return x.IsMod ? x.ModuleId : Enum.GetName(typeof(KMComponentPool.ComponentTypeEnum), x.ModuleType);
+				}, x => x);
+
+				ModulePool = Arguments.Select(Module => {
+					if (!reverseLookup.ContainsKey(Module))
+						throw new InvalidOperationException($"This distribution contains a fixed pool, and at least one of the modules in that pool ({Module}) is not enabled.");
+					return reverseLookup[Module];
+				}).ToList();
+				break;
+
 			default:
-				throw new InvalidOperationException("One of the pools in this distribution is not set up properly.");
+				throw new InvalidOperationException($"The following pool definition is invalid: \"{__poolDef}\"");
 		}
+
+		if ((ModulePool?.Count ?? 0) == 0) // Anti-softlock
+			throw new InvalidOperationException($"No enabled modules fit the requirements of the following pool: \"{__poolDef}\"");
+		return new KMComponentPool()
+		{
+			ComponentTypes = ModulePool.Where(x => !x.IsMod).Select(x => x.ModuleType).ToList(),
+			ModTypes = ModulePool.Where(x => x.IsMod).Select(x => x.ModuleId).ToList(),
+			Count = count
+		};
 	}
 
 	public int RewardPointsGiven(int count)
@@ -276,7 +334,7 @@ public sealed class DistributionPool : ISerializable
 		if (RewardPerModule != -1)
 			return RewardPerModule * count;
 
-		if (Type == PoolType.AllSolvable && ExtraData[0] == (int) KMComponentPool.ComponentSource.Base)
+		if (Type == PoolType.AllSolvable && PoolSettings["Component Source"] == (int) KMComponentPool.ComponentSource.Base)
 			return 2 * count;
 		return 5 * count;
 	}
@@ -286,7 +344,7 @@ public sealed class DistributionPool : ISerializable
 		if (TimePerModule != -1)
 			return TimePerModule * count;
 
-		if (Type == PoolType.AllSolvable && ExtraData[0] == (int) KMComponentPool.ComponentSource.Base)
+		if (Type == PoolType.AllSolvable && PoolSettings["Component Source"] == (int) KMComponentPool.ComponentSource.Base)
 			return 60 * count;
 		return 120 * count;
 	}

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -154,7 +154,7 @@ public class TwitchPlaySettingsData
 			}
 		}},
 		{ "light", new ModuleDistributions {
-			DisplayName = "Mods",
+			DisplayName = "Light Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.8f, "AllSolvable: Base"),
 				new DistributionPool(0.2f, "AllSolvable: Mods"),
@@ -162,7 +162,7 @@ public class TwitchPlaySettingsData
 			Hidden = true
 		}},
 		{ "mixed", new ModuleDistributions {
-			DisplayName = "Mods",
+			DisplayName = "Mixed",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.5f, "AllSolvable: Base"),
 				new DistributionPool(0.5f, "AllSolvable: Mods"),
@@ -170,7 +170,7 @@ public class TwitchPlaySettingsData
 			Hidden = true
 		}},
 		{ "heavy", new ModuleDistributions {
-			DisplayName = "Mods",
+			DisplayName = "Heavy Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.2f, "AllSolvable: Base"),
 				new DistributionPool(0.8f, "AllSolvable: Mods"),
@@ -191,19 +191,11 @@ public class TwitchPlaySettingsData
 				new DistributionPool(1.0f, "AllSolvable"),
 			}
 		}},
-		{ "fair+modneedy", new ModuleDistributions {
-			DisplayName = "Fair + Mod Needy",
-			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "AllSolvable"),
-				new DistributionPool(0.0f, "AllNeedy: Mods", /* Reward */ 20, /* Time */ 0),
-			},
-			MinModules = 2
-		}},
 		{ "fair+needy", new ModuleDistributions {
 			DisplayName = "Fair + Needy",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(1.0f, "AllSolvable"),
-				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
+				new DistributionPool(0.0f, "AllNeedy: Mods", /* Reward */ 20, /* Time */ 0),
 			},
 			MinModules = 2
 		}},
@@ -211,8 +203,8 @@ public class TwitchPlaySettingsData
 			DisplayName = "Fair + 2 Needies",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(1.0f, "AllSolvable"),
-				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
-				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
+				new DistributionPool(0.0f, "AllNeedy: Mods", /* Reward */ 20, /* Time */ 0),
+				new DistributionPool(0.0f, "AllNeedy: Mods", /* Reward */ 20, /* Time */ 0),
 			},
 			MinModules = 3
 		}},
@@ -249,7 +241,7 @@ public class TwitchPlaySettingsData
 				new DistributionPool(0.3f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
 			}
 		}},
-		{ "easy", new ModuleDistributions {
+		{ "mixedeasy", new ModuleDistributions {
 			DisplayName = "Easy Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.5f, "AllSolvable"),
@@ -277,7 +269,7 @@ public class TwitchPlaySettingsData
 				new DistributionPool(0.3f, "Score: > 7, <= 14"),
 			}
 		}},
-		{ "medium", new ModuleDistributions {
+		{ "mixedmedium", new ModuleDistributions {
 			DisplayName = "Medium Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.5f, "AllSolvable"),
@@ -306,7 +298,7 @@ public class TwitchPlaySettingsData
 				new DistributionPool(0.1f, "Score: > 14",        /* Reward */ 10, /* Time */ 240),
 			}
 		}},
-		{ "hard", new ModuleDistributions {
+		{ "mixedhard", new ModuleDistributions {
 			DisplayName = "Hard Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.5f, "AllSolvable"),
@@ -334,11 +326,32 @@ public class TwitchPlaySettingsData
 		{ "variety", new ModuleDistributions {
 			DisplayName = "Variety Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.30f, "Score: <= 7",        /* Reward */ 3,  /* Time */ 120),
-				new DistributionPool(0.25f, "Score: > 7, <= 14"),
-				new DistributionPool(0.20f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
-				new DistributionPool(0.25f, "AllSolvable"),
+				new DistributionPool(0.11f, "Score: <= 4",         /* Reward */ 2,  /* Time */ 60),
+				new DistributionPool(0.15f, "Score: <= 9",         /* Reward */ 3,  /* Time */ 120),
+				new DistributionPool(0.15f, "Score: >= 5, <= 14"),
+				new DistributionPool(0.13f, "Score: >= 5, <= 19"),
+				new DistributionPool(0.13f, "Score: >= 10, <= 24"),
+				new DistributionPool(0.11f, "Score: >= 10, <= 29", /* Reward */ 8,  /* Time */ 180),
+				new DistributionPool(0.09f, "Score: >= 20",        /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.13f, "AllSolvable"),
 			}
+		}},
+		{ "variety+boss", new ModuleDistributions {
+			DisplayName = "Variety + Boss",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.11f, "Score: <= 4",         /* Reward */ 2,  /* Time */ 60),
+				new DistributionPool(0.15f, "Score: <= 9",         /* Reward */ 3,  /* Time */ 120),
+				new DistributionPool(0.15f, "Score: >= 5, <= 14"),
+				new DistributionPool(0.13f, "Score: >= 5, <= 19"),
+				new DistributionPool(0.13f, "Score: >= 10, <= 24"),
+				new DistributionPool(0.11f, "Score: >= 10, <= 29", /* Reward */ 8,  /* Time */ 180),
+				new DistributionPool(0.09f, "Score: >= 20",        /* Reward */ 10, /* Time */ 240),
+
+				new DistributionPool(0.0865f, "AllSolvable"),
+				new DistributionPool(0.0435f, "DisabledBy: NoBossModules", /* Reward */ 0, /* Time */ 300),
+				new DistributionPool(0.0f,    "DisabledBy: NoBossModules", /* Reward */ 0, /* Time */ 300),
+			},
+			MinModules = 2
 		}}
 	};
 

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -238,27 +238,27 @@ public class TwitchPlaySettingsData
 			DisplayName = "Light Easy Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.7f, "AllSolvable"),
-				new DistributionPool(0.3f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
+				new DistributionPool(0.3f, "Score: <= 7", /* Reward */ 3),
 			}
 		}},
 		{ "mixedeasy", new ModuleDistributions {
 			DisplayName = "Easy Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.5f, "AllSolvable"),
-				new DistributionPool(0.5f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
+				new DistributionPool(0.5f, "Score: <= 7", /* Reward */ 3),
 			}
 		}},
 		{ "heavyeasy", new ModuleDistributions {
 			DisplayName = "Heavy Easy Mix",
 			Pools = new List<DistributionPool> {
 				new DistributionPool(0.2f, "AllSolvable"),
-				new DistributionPool(0.8f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
+				new DistributionPool(0.8f, "Score: <= 7", /* Reward */ 3),
 			}
 		}},
 		{ "alleasy", new ModuleDistributions {
 			DisplayName = "All Easy",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
+				new DistributionPool(1.0f, "Score: <= 7", /* Reward */ 3),
 			}
 		}},
 

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -146,94 +146,97 @@ public class TwitchPlaySettingsData
 
 	public Dictionary<string, ModuleDistributions> ModDistributionSettings = new Dictionary<string, ModuleDistributions>()
 	{
-		// Non-difficulty related distributions
+		// Vanilla/Mod related distributions
 		{ "vanilla", new ModuleDistributions {
 			DisplayName = "Vanilla",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE, BASE"),
+				new DistributionPool(1.0f, "AllSolvable: Base"),
 			}
 		}},
 		{ "light", new ModuleDistributions {
 			DisplayName = "Mods",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.8f, "ALL_SOLVABLE, BASE"),
-				new DistributionPool(0.2f, "ALL_SOLVABLE, MODS"),
+				new DistributionPool(0.8f, "AllSolvable: Base"),
+				new DistributionPool(0.2f, "AllSolvable: Mods"),
 			},
 			Hidden = true
 		}},
 		{ "mixed", new ModuleDistributions {
 			DisplayName = "Mods",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.5f, "ALL_SOLVABLE, BASE"),
-				new DistributionPool(0.5f, "ALL_SOLVABLE, MODS"),
+				new DistributionPool(0.5f, "AllSolvable: Base"),
+				new DistributionPool(0.5f, "AllSolvable: Mods"),
 			},
 			Hidden = true
 		}},
 		{ "heavy", new ModuleDistributions {
 			DisplayName = "Mods",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.2f, "ALL_SOLVABLE, BASE"),
-				new DistributionPool(0.8f, "ALL_SOLVABLE, MODS"),
+				new DistributionPool(0.2f, "AllSolvable: Base"),
+				new DistributionPool(0.8f, "AllSolvable: Mods"),
 			},
 			Hidden = true
 		}},
 		{ "mods", new ModuleDistributions {
 			DisplayName = "Mods",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE, MODS"),
+				new DistributionPool(1.0f, "AllSolvable: Mods"),
 			}
 		}},
+
+		// Fair Mix distributions
 		{ "fair", new ModuleDistributions {
 			DisplayName = "Fair Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
+				new DistributionPool(1.0f, "AllSolvable"),
 			}
 		}},
 		{ "fair+modneedy", new ModuleDistributions {
 			DisplayName = "Fair + Mod Needy",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY, MODS"),
+				new DistributionPool(1.0f, "AllSolvable"),
+				new DistributionPool(0.0f, "AllNeedy: Mods", /* Reward */ 20, /* Time */ 0),
 			},
 			MinModules = 2
 		}},
 		{ "fair+needy", new ModuleDistributions {
 			DisplayName = "Fair + Needy",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
+				new DistributionPool(1.0f, "AllSolvable"),
+				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
 			},
 			MinModules = 2
 		}},
 		{ "fair+2needies", new ModuleDistributions {
 			DisplayName = "Fair + 2 Needies",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
-				new DistributionPool(0.0f, 20, 0, "ALL_NEEDY"),
+				new DistributionPool(1.0f, "AllSolvable"),
+				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
+				new DistributionPool(0.0f, "AllNeedy", /* Reward */ 20, /* Time */ 0),
 			},
 			MinModules = 3
 		}},
 		{ "fair+needysometimes", new ModuleDistributions {
 			DisplayName = "Fair + Needy Sometimes",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "ALL_SOLVABLE"),
-				new DistributionPool(0.0f, "ALL_MODULES"),
+				new DistributionPool(1.0f, "AllSolvable"),
+				new DistributionPool(0.0f, "AllModules"),
 			},
 			MinModules = 2
 		}},
 		{ "fair+neediessometimes", new ModuleDistributions {
 			DisplayName = "Fair + Needies Sometimes",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.8f, "ALL_SOLVABLE"),
-				new DistributionPool(0.2f, "ALL_MODULES"),
-			},
+				new DistributionPool(0.8f, "AllSolvable"),
+				new DistributionPool(0.2f, "AllModules"),
+			}
 		}},
 		{ "chaos", new ModuleDistributions {
 			DisplayName = "Chaos",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.0f, "ALL_SOLVABLE"),
-				new DistributionPool(1.0f, "ALL_MODULES"),
+				new DistributionPool(1.0f, "AllModules"),
+				// Must have one guaranteed solvable to avoid possible softlocks
+				new DistributionPool(0.0f, "AllSolvable"),
 			},
 			MinModules = 2
 		}},
@@ -242,95 +245,99 @@ public class TwitchPlaySettingsData
 		{ "lighteasy", new ModuleDistributions {
 			DisplayName = "Light Easy Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.7f, "ALL_SOLVABLE"),
-				new DistributionPool(0.3f, 3, 120, "SCORE, <= 7")
+				new DistributionPool(0.7f, "AllSolvable"),
+				new DistributionPool(0.3f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
 			}
 		}},
 		{ "easy", new ModuleDistributions {
 			DisplayName = "Easy Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.5f, "ALL_SOLVABLE"),
-				new DistributionPool(0.5f, 3, 120, "SCORE, <= 7")
+				new DistributionPool(0.5f, "AllSolvable"),
+				new DistributionPool(0.5f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
 			}
 		}},
 		{ "heavyeasy", new ModuleDistributions {
 			DisplayName = "Heavy Easy Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.2f, "ALL_SOLVABLE"),
-				new DistributionPool(0.8f, 3, 120, "SCORE, <= 7")
+				new DistributionPool(0.2f, "AllSolvable"),
+				new DistributionPool(0.8f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
 			}
 		}},
 		{ "alleasy", new ModuleDistributions {
 			DisplayName = "All Easy",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, 3, 120, "SCORE, <= 7")
+				new DistributionPool(1.0f, "Score: <= 7", /* Reward */ 3, /* Time */ 120),
 			}
 		}},
+
 		{ "lightmedium", new ModuleDistributions {
 			DisplayName = "Light Medium Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.7f, "ALL_SOLVABLE"),
-				new DistributionPool(0.3f, "SCORE, > 7, <= 14")
+				new DistributionPool(0.7f, "AllSolvable"),
+				new DistributionPool(0.3f, "Score: > 7, <= 14"),
 			}
 		}},
 		{ "medium", new ModuleDistributions {
 			DisplayName = "Medium Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.5f, "ALL_SOLVABLE"),
-				new DistributionPool(0.5f, "SCORE, > 7, <= 14")
+				new DistributionPool(0.5f, "AllSolvable"),
+				new DistributionPool(0.5f, "Score: > 7, <= 14"),
 			}
 		}},
 		{ "heavymedium", new ModuleDistributions {
 			DisplayName = "Heavy Medium Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.2f, "ALL_SOLVABLE"),
-				new DistributionPool(0.8f, "SCORE, > 7, <= 14")
+				new DistributionPool(0.2f, "AllSolvable"),
+				new DistributionPool(0.8f, "Score: > 7, <= 14"),
 			}
 		}},
 		{ "allmedium", new ModuleDistributions {
 			DisplayName = "All Medium",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(1.0f, "SCORE, > 7, <= 14")
+				new DistributionPool(1.0f, "Score: > 7, <= 14"),
 			}
 		}},
+
 		{ "lighthard", new ModuleDistributions {
 			DisplayName = "Light Hard Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.7f, "ALL_SOLVABLE"),
-				new DistributionPool(0.2f, 10, 240, "SCORE, > 14, <= 25"),
-				new DistributionPool(0.1f, 10, 240, "SCORE, > 14")
+				new DistributionPool(0.7f, "AllSolvable"),
+				new DistributionPool(0.2f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.1f, "Score: > 14",        /* Reward */ 10, /* Time */ 240),
 			}
 		}},
 		{ "hard", new ModuleDistributions {
 			DisplayName = "Hard Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.5f, "ALL_SOLVABLE"),
-				new DistributionPool(0.3f, 10, 240, "SCORE, > 14, <= 25"),
-				new DistributionPool(0.2f, 10, 240, "SCORE, > 14")
+				new DistributionPool(0.5f, "AllSolvable"),
+				new DistributionPool(0.3f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.2f, "Score: > 14",        /* Reward */ 10, /* Time */ 240),
 			}
 		}},
 		{ "heavyhard", new ModuleDistributions {
 			DisplayName = "Heavy Hard Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.2f, "ALL_SOLVABLE"),
-				new DistributionPool(0.5f, 10, 240, "SCORE, > 14, <= 25"),
-				new DistributionPool(0.3f, 10, 240, "SCORE, > 14")
+				new DistributionPool(0.2f, "AllSolvable"),
+				new DistributionPool(0.5f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.3f, "Score: > 14",        /* Reward */ 10, /* Time */ 240),
 			}
 		}},
 		{ "allhard", new ModuleDistributions {
 			DisplayName = "All Hard",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.6f, 10, 240, "SCORE, > 14, <= 25"),
-				new DistributionPool(0.4f, 10, 240, "SCORE, > 14")
+				new DistributionPool(0.6f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.4f, "Score: > 14",        /* Reward */ 10, /* Time */ 240),
 			}
 		}},
+
+		// Variety distributions
 		{ "variety", new ModuleDistributions {
 			DisplayName = "Variety Mix",
 			Pools = new List<DistributionPool> {
-				new DistributionPool(0.30f, 3, 120, "SCORE, <= 7"),
-				new DistributionPool(0.25f, "SCORE, > 7, <= 14"),
-				new DistributionPool(0.20f, 10, 240, "SCORE, > 14, <= 25"),
-				new DistributionPool(0.25f, "ALL_SOLVABLE")
+				new DistributionPool(0.30f, "Score: <= 7",        /* Reward */ 3,  /* Time */ 120),
+				new DistributionPool(0.25f, "Score: > 7, <= 14"),
+				new DistributionPool(0.20f, "Score: > 14, <= 25", /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.25f, "AllSolvable"),
 			}
 		}}
 	};


### PR DESCRIPTION
Adds "EnabledBy" and "DisabledBy" pools to distributions, to allow for much more flexibility; "DisabledBy: NoBossModules" is a quick way to guarantee a boss module shows up, for instance.

In addition, a whole bunch of cleanup has been done with the resulting code and settings to hopefully make it easier for others to read and understand how distributions work and how they're set up.

The last commit features a couple tweaks to the default set of distributions:
- Fixed the display names of 'light', 'mixed', and 'heavy'
- Removed 'fair+modneedy' in favor of making the 'fair+needy' and 'fair+2needies' distributions use mod needies only, as base needies cannot be disabled via profiles (and Needy Capacitor exists)
- Renamed 'easy', 'medium', and 'hard' to 'mixedeasy', 'mixedmedium', and 'mixedhard' respectively, to match the vanilla/mods ratio 'mixed' distribution; this way all the difficulty based distributions are clear about how many easy/medium/hard modules you're getting
- Changed 'variety' to actually be a proper variety instead of halfheartedly stuffing the above three distributions together, and
add a 'variety+boss' that uses the new profile pools (because it's much less likely for bosses to show up in it, and people do like running bosses sometimes)

