### PR TITLE
Use the Repository's "boss status" and "quirks" fields

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -760,6 +760,8 @@ public static class ComponentSolverFactory
 		{
 			var defaultInfo = GetDefaultInformation(item.ModuleID);
 			defaultInfo.announceModule |= item.ModuleID.IsBossMod();
+			defaultInfo.announceModule |= item.ModuleID.ModHasQuirk("NeedsImmediateAttention");
+			defaultInfo.announceModule |= item.ModuleID.ModHasQuirk("PseudoNeedy");
 		}
 
 		if (reloadData)

--- a/TwitchPlaysAssembly/Src/Helpers/Repository.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/Repository.cs
@@ -20,7 +20,13 @@ public static class Repository
 		Modules = JsonConvert.DeserializeObject<WebsiteJSON>(RawJSON).KtaneModules;
 	}
 
-	public static bool IsBossMod(this string moduleID) => Modules.Any(module => module.ModuleID == moduleID && module.Ignore != null);
+	public static bool IsBossMod(this string moduleID) => Modules.Any(module => module.ModuleID == moduleID && module.BossStatus != null);
+
+	public static bool ModHasQuirk(this string moduleID, string quirk)
+	{
+		var match = Modules?.Find(module => module.ModuleID == moduleID);
+		return (match?.Quirks ?? "").Contains(quirk);
+	}
 
 	public static string GetManual(string moduleID)
 	{
@@ -44,7 +50,8 @@ public static class Repository
 		public string FileName;
 		public Dictionary<string, object> TwitchPlays;
 
-		public List<string> Ignore;
+		public string BossStatus;
+		public string Quirks;
 	}
 #pragma warning restore CS0649
 }


### PR DESCRIPTION
This more closely aligns what we consider a "boss module" with what the repo considers one; using the presence of an ignore list results in things like Four Card Monte and Encryption Bingo both being considered bosses when they don't (or in EB's case, no longer) actually act like one.

Default announcements are now for boss modules + pseudo needies + any module that needs immediate attention. An additional automatic profile to disable pseudo needies has been added. Obviously more can be done with quirks later, but this is a good start.