### PR TITLE
A bunch of fixes to zooming and tilting

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -336,8 +336,7 @@ static class ModuleCommands
 
 	public static IEnumerator Zoom(TwitchModule module, SuperZoomData zoomData, object yield)
 	{
-		float alpha = module.CanvasGroupMultiDecker.alpha;
-		module.CanvasGroupMultiDecker.alpha = 0.0f;
+		module.HideBanner();
 
 		var zoomCoroutine = TwitchGame.ModuleCameras?.ZoomCamera(module, zoomData, 1);
 		if (zoomCoroutine != null)
@@ -348,13 +347,12 @@ static class ModuleCommands
 
 		if (CoroutineCanceller.ShouldCancel)
 		{
-			module.CanvasGroupMultiDecker.alpha = alpha;
+			module.ShowBanner(0.0f);
 			module.StartCoroutine(TwitchGame.ModuleCameras?.UnzoomCamera(module, zoomData, 0));
 			yield break;
 		}
 
-		module.CanvasGroupMultiDecker.alpha = alpha;
-
+		module.ShowBanner();
 		var unzoomCoroutine = TwitchGame.ModuleCameras?.UnzoomCamera(module, zoomData, 1);
 		if (unzoomCoroutine != null)
 			while (unzoomCoroutine.MoveNext())
@@ -399,10 +397,7 @@ static class ModuleCommands
 		while (focusCoroutine.MoveNext())
 			yield return focusCoroutine.Current;
 
-		float moduleAlpha = module.CanvasGroupMultiDecker.alpha;
-		if (moduleAlpha != 0.0f)
-			module.CanvasGroupMultiDecker.alpha = 0.0f;
-
+		module.HideBanner(0.5f);
 		yield return new WaitForSeconds(0.5f);
 
 		var targetAngle = Quaternion.Euler(new Vector3(-Mathf.Cos(targetRotation * Mathf.Deg2Rad), 0, Mathf.Sin(targetRotation * Mathf.Deg2Rad)) * (module.FrontFace ? tiltAngle : -tiltAngle));
@@ -424,8 +419,7 @@ static class ModuleCommands
 			module.Bomb.RotateByLocalQuaternion(bombAngle);
 			TwitchBomb.RotateCameraByLocalQuaternion(module.BombComponent.gameObject, angle);
 			module.StartCoroutine(module.Bomb.Defocus(module.Selectable, module.FrontFace, false));
-			if (moduleAlpha != 0.0f)
-				module.CanvasGroupMultiDecker.alpha = moduleAlpha;
+			module.ShowBanner(0.0f);
 			yield break;
 		}
 
@@ -438,9 +432,7 @@ static class ModuleCommands
 			yield return null;
 		}
 
-		if (moduleAlpha != 0.0f)
-			module.CanvasGroupMultiDecker.alpha = moduleAlpha;
-
+		module.ShowBanner(0.5f);
 		IEnumerator defocusCoroutine = module.Bomb.Defocus(module.Selectable, module.FrontFace, false);
 		while (defocusCoroutine.MoveNext())
 			yield return defocusCoroutine.Current;

--- a/TwitchPlaysAssembly/Src/UI/TwitchBomb.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchBomb.cs
@@ -54,6 +54,9 @@ public class TwitchBomb : MonoBehaviour
 
 	private bool _flipEnabled = true;
 
+	private int _focusCount = 0;
+	private int _focusSelectCount = 0;
+
 	public string BombName
 	{
 		get => _bombName;
@@ -514,12 +517,16 @@ public class TwitchBomb : MonoBehaviour
 		while (holdCoroutine.MoveNext())
 			yield return holdCoroutine.Current;
 
-		var holdable = Bomb.GetComponent<FloatingHoldable>();
-		float focusTime = holdable.FocusTime;
-		holdable.Focus(selectable.transform, focusDistance, false, false, focusTime);
+		if (_focusCount++ == 0)
+		{
+			var holdable = Bomb.GetComponent<FloatingHoldable>();
+			float focusTime = holdable.FocusTime;
+			holdable.Focus(selectable.transform, focusDistance, false, false, focusTime);
 
-		if (select) selectable.HandleSelect(false);
-		selectable.HandleInteract();
+			selectable.HandleInteract();
+		}
+		if (select && _focusSelectCount++ == 0)
+			selectable.HandleSelect(false);
 	}
 
 	public IEnumerator Defocus(Selectable selectable, bool frontFace, bool deselect = true)
@@ -534,11 +541,19 @@ public class TwitchBomb : MonoBehaviour
 				yield break;
 		}
 
-		selectable.OnDefocus?.Invoke();
+		if (--_focusCount <= 0)
+		{
+			selectable.OnDefocus?.Invoke();
 
-		Bomb.GetComponent<FloatingHoldable>().Defocus(false, false);
-		if (deselect) selectable.HandleDeselect();
-		selectable.HandleCancel();
+			Bomb.GetComponent<FloatingHoldable>().Defocus(false, false);
+			selectable.HandleCancel();
+			_focusCount = 0;
+		}
+		if (deselect && --_focusSelectCount <= 0)
+		{
+			selectable.HandleDeselect();
+			_focusSelectCount = 0;
+		}
 	}
 
 	public void RotateByLocalQuaternion(Quaternion localQuaternion)


### PR DESCRIPTION
- Smoothly fade out the banner when hiding it for zooms and tilts (I feel it makes it easier to understand what's happening with a fade)
- Fix banner reappearing if module is solved while zoomed
- Only allow one focus at a time, keep track of the number of focus requests and require that many defocus requests to actually defocus (fixes Finite Loop)