### PR TITLE
fix secure connection by using TLS 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ sysinfo.txt
 /Assets/Editor/Resources/WorkshopItem.asset.meta
 /Assets/Plugins/Managed/TwitchPlaysAssembly.*
 !/Assets/Plugins/Managed/TwitchPlaysAssembly.dll.meta
+/Assets/Plugins/Managed/BouncyCastle.Crypto.*
+!/Assets/Plugins/Managed/BouncyCastle.Crypto.dll.meta

--- a/Assets/Plugins/Managed/BouncyCastle.Crypto.dll.meta
+++ b/Assets/Plugins/Managed/BouncyCastle.Crypto.dll.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 4c4bbe40bd753304a841aa0e29ff927f
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TwitchPlaysAssembly/Src/Helpers/TPTlsClient.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/TPTlsClient.cs
@@ -1,0 +1,67 @@
+﻿using System.Linq;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Tls;
+
+
+// TLS Client, adapted from https://stackoverflow.com/questions/68317182/how-to-create-a-tls-connection-with-bouncycastle-in-c
+// TODO: allow authenticating with loaded X509 keys - not required for twitch
+public class TPTlsClient : DefaultTlsClient
+{
+	public override TlsAuthentication GetAuthentication()
+	{
+		return new TPTlsAuthentication(Certificate.EmptyChain.GetCertificateList(), null, mContext);
+	}
+}
+
+internal class TPTlsAuthentication : TlsAuthentication
+{
+	private Certificate CertChain;
+	private AsymmetricKeyParameter PrivateKey;
+	private TlsContext TlsContext;
+	private bool AuthenticateClient;
+
+	public TPTlsAuthentication(X509CertificateStructure[] certChain, AsymmetricKeyParameter privateKey, TlsContext context, bool authenticateClient = false)
+	{
+		CertChain = new Certificate(certChain);
+		TlsContext = context;
+		PrivateKey = privateKey;
+		AuthenticateClient = authenticateClient;
+	}
+
+	public TlsCredentials GetClientCredentials(CertificateRequest certificateRequest)
+	{
+		if (AuthenticateClient)
+		{
+			byte[] certificateTypes = certificateRequest.CertificateTypes;
+			if (certificateTypes == null || !certificateTypes.Contains(ClientCertificateType.rsa_sign))
+				return null;
+
+			SignatureAndHashAlgorithm sigHashAlgorithm = null;
+			if (certificateRequest.SupportedSignatureAlgorithms != null)
+			{
+				foreach (SignatureAndHashAlgorithm algorithm in certificateRequest.SupportedSignatureAlgorithms)
+				{
+					if (algorithm.Signature == SignatureAlgorithm.rsa)
+					{
+						sigHashAlgorithm = algorithm;
+						break;
+					}
+				}
+
+				if (sigHashAlgorithm == null)
+					return null;
+			}
+
+			TlsCredentials credentials = new DefaultTlsSignerCredentials(TlsContext, CertChain, PrivateKey, sigHashAlgorithm);
+			return credentials;
+		}
+		else
+			return null;
+	}
+
+	public void NotifyServerCertificate(Certificate serverCertificate)
+	{
+		//we are supposed to validate the server certificate here, but there's literally nothing we can do to do that
+	}
+}

--- a/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
+++ b/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
@@ -90,4 +90,7 @@
   <ItemGroup>
     <None Include=".editorconfig" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BouncyCastle" Version="1.8.9" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
**This PR adds the BouncyCastle NuGet package as a dependency**

Since Twitch stopped accepting TLS 1.0, and the unfortunate combination of the mono/unity version we use, the version the game uses, and the .net version TP uses restricts us to using TLS 1.0 via inbuilt methods, I have included a reference to the BouncyCastle cryptography package to provide the TLS 1.2 client.

The version we are using is quite out of date, however this is necessary as newer versions do not support .net 3.5, only 4.6+
The version also does not support TLS 1.3, however, 1.2 should be supported for a good while longer.

I have tested this locally, and can confirm that the secure connection works again