### PR TITLE
Reuse `!solvebomb` logic for `!newbomb` (just call SolveBomb())

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -431,13 +431,7 @@ static class GameCommands
 		else
 		{
 			TwitchPlaySettings.AddRewardBonus(-TwitchPlaySettings.GetRewardBonus());
-
-			foreach (var bomb in TwitchGame.Instance.Bombs.Where(x => GameRoom.Instance.IsCurrentBomb(x.BombID)))
-				bomb.StartCoroutine(bomb.KeepAlive());
-
-			foreach (var module in TwitchGame.Instance.Modules.Where(x => GameRoom.Instance.IsCurrentBomb(x.BombID)))
-				if (!module.Solved)
-					module.SolveSilently();
+			SolveBomb();
 		}
 	}
 


### PR DESCRIPTION
Fixes exception on `!newbomb` if no modules had autosolvers.