### PR TITLE
Fix Jackbox.TV connection error button

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/JackboxTVComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/JackboxTVComponentSolver.cs
@@ -17,7 +17,7 @@ public class JackboxTVComponentSolver : ReflectionComponentSolver
 		}
 
 		yield return null;
-		yield return Click(0, 0);
+		yield return DoInteractionClick(Module.Selectable.Children[0], 0);
 	}
 
 	protected override IEnumerator ForcedSolveIEnumerator()
@@ -25,7 +25,7 @@ public class JackboxTVComponentSolver : ReflectionComponentSolver
 		yield return null;
 
 		if (_component.GetValue<bool>("isSolved"))
-			yield return Click(0);
+			yield return DoInteractionClick(Module.Selectable.Children[0]);
 		else
 			yield return _component.CallMethod<IEnumerator>("WSSolve", "TP Autosolver");
 	}


### PR DESCRIPTION
Fixes the TP for Jackbox.TV not accounting for the module's selectable children array changing after it generates if an error occurs causing it to press the wrong thing if you try to use !# s if a connection error occurs.