### PR TITLE
Add 3 shims to fix old broken module commands

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -288,6 +288,9 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreators["simonSamples"] = module => new SimonSamplesShim(module);
 		ModComponentSolverCreators["DIWindow"] = module => new DriveInWindowShim(module);
 		ModComponentSolverCreators["chip"] = module => new ChipShim(module);
+		ModComponentSolverCreators["AlienModule"] = module => new AlienFilingColorsShim(module);
+		ModComponentSolverCreators["SimonsSatire"] = module => new SimonsSatireShim(module);
+		ModComponentSolverCreators["double_on"] = module => new DoubleOnShim(module);
 
 		// Anti-troll shims - These are specifically meant to allow the troll commands to be disabled.
 		ModComponentSolverCreators["MazeV2"] = module => new AntiTrollShim(module, new Dictionary<string, string> { { "spinme", "Sorry, I am not going to waste time spinning every single pipe 360 degrees." } });

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/AlienFilingColorsShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/AlienFilingColorsShim.cs
@@ -19,6 +19,7 @@ public class AlienFilingColorsShim : ReflectionComponentSolverShim
 					yield break;
 			}
 		}
+
 		yield return RespondUnshimmed(command);
 	}
 

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/AlienFilingColorsShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/AlienFilingColorsShim.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Linq;
+
+public class AlienFilingColorsShim : ReflectionComponentSolverShim
+{
+	public AlienFilingColorsShim(TwitchModule module)
+		: base(module, "AFCScript", "AlienModule")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+	}
+
+	protected override IEnumerator RespondShimmed(string[] split, string command)
+	{
+		if (!command.EqualsAny("colorblind", "colourblind", "cb"))
+		{
+			foreach (char c in command)
+			{
+				if (!_validChars.Contains(c))
+					yield break;
+			}
+		}
+		yield return RespondUnshimmed(command);
+	}
+
+	private readonly char[] _validChars = { '1', '2', '3', '4', '5', '6', '7', '8', ' ', ',', '|', '-' };
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/DoubleOnShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/DoubleOnShim.cs
@@ -24,8 +24,7 @@ public class DoubleOnShim : ReflectionComponentSolverShim
 				yield break;
 			}
 		}
+
 		yield return RespondUnshimmed(command);
 	}
-
-	private readonly char[] _validChars = { '1', '2', '3', '4', '5', '6', '7', '8', ' ', ',', '|', '-' };
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/DoubleOnShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/DoubleOnShim.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class DoubleOnShim : ReflectionComponentSolverShim
+{
+	public DoubleOnShim(TwitchModule module)
+		: base(module, "DoubleOnModule", "double_on")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+	}
+
+	protected override IEnumerator RespondShimmed(string[] split, string command)
+	{
+		if (!command.Equals("read"))
+		{
+			if (!Regex.IsMatch(command, @"^([1-9]\d*[rgbcmy]{2}( +|$))+$")) yield break;
+			string[] subCommands = split.Where(s => s.Length > 0).ToArray();
+			int[] btnIndices = subCommands.Select(s => int.Parse(s.Take(s.Length - 2).Join("")) - 1).ToArray();
+			if (btnIndices.Any(b => b >= _component.GetValue<object>("_puzzle").GetValue<Vector2Int[]>("LEDPositions").Length))
+			{
+				yield return "sendtochaterror {0}, !{1} invalid LED id.";
+				yield break;
+			}
+		}
+		yield return RespondUnshimmed(command);
+	}
+
+	private readonly char[] _validChars = { '1', '2', '3', '4', '5', '6', '7', '8', ' ', ',', '|', '-' };
+}

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
@@ -16,17 +16,21 @@ public class SimonsSatireShim : ReflectionComponentSolverShim
 		{
 			if (!split[0].Equals("press"))
 				yield break;
+
 			yield return null;
+
 			if (split.Length < 2)
 			{
 				yield return "sendtochaterror Parameter length invalid. Command ignored.";
 				yield break;
 			}
+
 			if (!_validButtons.Contains(split[1]))
 			{
 				yield return "sendtochaterror Command contains an invalid color. Command ignored.";
 				yield break;
 			}
+
 			switch (split[1])
 			{
 				case "red":
@@ -46,8 +50,8 @@ public class SimonsSatireShim : ReflectionComponentSolverShim
 					break;
 			}
 		}
-		else
-			yield return RespondUnshimmed(command);
+
+		yield return RespondUnshimmed(command);
 	}
 
 	private readonly string[] _validButtons = { "red", "blue", "yellow", "green", "r", "b", "y", "g" };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Linq;
+
+public class SimonsSatireShim : ReflectionComponentSolverShim
+{
+	public SimonsSatireShim(TwitchModule module)
+		: base(module, "SimonsSatireModule", "42069")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType());
+		_buttons = new KMSelectable[] { _component.GetValue<KMSelectable>("RedButton"), _component.GetValue<KMSelectable>("BlueButton"), _component.GetValue<KMSelectable>("YellowButton"), _component.GetValue<KMSelectable>("GreenButton") };
+	}
+
+	protected override IEnumerator RespondShimmed(string[] split, string command)
+	{
+		if (!command.EqualsAny("left", "right") && split.Length < 3)
+		{
+			if (!split[0].Equals("press"))
+				yield break;
+			yield return null;
+			if (split.Length < 2)
+			{
+				yield return "sendtochaterror Parameter length invalid. Command ignored.";
+				yield break;
+			}
+			if (!_validButtons.Contains(split[1]))
+			{
+				yield return "sendtochaterror Command contains an invalid color. Command ignored.";
+				yield break;
+			}
+			switch (split[1])
+			{
+				case "red":
+				case "r":
+					yield return DoInteractionClick(_buttons[0]);
+					break;
+				case "blue":
+				case "b":
+					yield return DoInteractionClick(_buttons[1]);
+					break;
+				case "yellow":
+				case "y":
+					yield return DoInteractionClick(_buttons[2]);
+					break;
+				default:
+					yield return DoInteractionClick(_buttons[3]);
+					break;
+			}
+		}
+		else
+			yield return RespondUnshimmed(command);
+	}
+
+	private readonly string[] _validButtons = { "red", "blue", "yellow", "green", "r", "b", "y", "g" };
+	private readonly KMSelectable[] _buttons;
+}


### PR DESCRIPTION
These modules don't seem like they are getting a fix from their authors anytime soon so I'm putting the fixes TP side instead for now.

- Fixed Alien Filing Colors skipping to getting the valid number positions in the command and not checking for any invalid characters that the help message doesnt use.
- Fixed Double-On throwing an exception if you tried to specify a non-existent LED due to a wrong array length being used in the original code.
- Fixed Simon's Satire throwing an exception on the normal press command due to the command parameter length not being checked properly in the original code.