### PR TITLE
Fix Keep Clicking, Simon's Satire, and Large Password (hopefully)

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonsSatireShim.cs
@@ -50,8 +50,8 @@ public class SimonsSatireShim : ReflectionComponentSolverShim
 					break;
 			}
 		}
-
-		yield return RespondUnshimmed(command);
+		else
+			yield return RespondUnshimmed(command);
 	}
 
 	private readonly string[] _validButtons = { "red", "blue", "yellow", "green", "r", "b", "y", "g" };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/KeepClickingComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/StrangaDanga/KeepClickingComponentSolver.cs
@@ -44,7 +44,7 @@ public class KeepClickingComponentSolver : ReflectionComponentSolver
 				type = 1;
 			else
 			{
-				foreach (string r in edgework.GetIndicators())
+				foreach (string r in edgework.GetOnIndicators())
 				{
 					if (r.EndsWith("R"))
 					{

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/LargePasswordComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/TheDarkSid3r/LargePasswordComponentSolver.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 public class LargePasswordComponentSolver : ReflectionComponentSolver
 {
 	public LargePasswordComponentSolver(TwitchModule module) :
-		base(module, "LargeVanillaPassword", "!{0} cycle 1 13 8 [Cycle through the letters in columns 1, 13, and 8] | !{0} toggle [Move all columns down one letter] | !{0} world about still water [Try to submit words]")
+		base(module, "LargeVanillaPassword", "LargeVanillaPassword", "!{0} cycle 1 13 8 [Cycle through the letters in columns 1, 13, and 8] | !{0} toggle [Move all columns down one letter] | !{0} world about still water [Try to submit words]")
 	{
 	}
 


### PR DESCRIPTION
I misread a rule when making the Keep Clicking solve handler initially and it got all indicators instead of all lit indicators. This fixes that issue. I also forgot to have Simon's Satire stop the shim if it handled pressing a button so it would still execute broken code. This also fixes that issue. Lastly, Large Password sometimes throws a null ref when trying to get the list of chars for the spinners which I believe is caused by the game being confused with LargeVanillaPassword being a script name in multiple mods. This should fix that potential issue by including the assembly name for it as well.