### PR TITLE
Add Setting for Normal Mode Starting Time

### DIFF
--- a/TwitchPlaysAssembly/Src/ModuleDistributions.cs
+++ b/TwitchPlaysAssembly/Src/ModuleDistributions.cs
@@ -319,7 +319,7 @@ public sealed class DistributionPool : ISerializable
 	private bool IsVanillaPool() => Type == PoolType.AllSolvable && PoolSettings["Component Source"] == (int) KMComponentPool.ComponentSource.Base;
 
 	public int RewardPointsGiven(int count) => (RewardPerModule ?? (IsVanillaPool() ? 2 : 5)) * count;
-	public int TimeGiven(int count) => (TimePerModule ?? (IsVanillaPool() ? 60 : 120)) * count;
+	public int TimeGiven(int count) => (TimePerModule ?? (IsVanillaPool() ? 60 : TwitchPlaySettings.data.NormalModeSecondsPerModule)) * count;
 }
 
 public sealed class ModuleDistributions

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -84,6 +84,7 @@ public class TwitchPlaySettingsData
 	public int MinScoreForNewbomb = 100;
 	public int StrikePenalty = 6;
 	public int ModuleToStrikeRatio = 12;
+	public int NormalModeSecondsPerModule = 120;
 	public bool PacingEventsOnRunBomb = true;
 	public bool AllowSheetDisabledModules = true;
 


### PR DESCRIPTION
As discussed in the TP Discord Server, bombs require more time due to the increased complexity of new modules. This PR makes the starting time of Normal Mode bombs (through the !run command) a setting. The default remains the same, although we will likely be changing this on the livestream. 