### PR TITLE
BossModules pool type & Strict Difficulty Distributions

### DIFF
--- a/TwitchPlaysAssembly/Src/ModuleDistributions.cs
+++ b/TwitchPlaysAssembly/Src/ModuleDistributions.cs
@@ -49,8 +49,7 @@ public sealed class DistributionPool : ISerializable
 		ProfileEnables,
 
 		// Adds a pool containing all solvable modules disabled by a defuser profile
-		// Examples:
-		//     DisabledBy: NoBossModules
+		// Example:
 		//     DisabledBy: NoColCipher, NoDream (modules disabled by both)
 		ProfileDisables,
 
@@ -62,6 +61,12 @@ public sealed class DistributionPool : ISerializable
 		//     Fixed: brainf, HexiEvilFMN (pick between two)
 		//     Fixed: Wires, Wires, Wires, Wires, Venn (80% Wires, 20% Complicated Wires)
 		Fixed,
+
+		// Adds a pool containing all modules that are announced at the start of a bomb,
+		// typically indicating a boss module.
+		// Example: 
+		//		"BossModule"
+		BossModule,
 	}
 
 	private readonly int? RewardPerModule;
@@ -182,6 +187,11 @@ public sealed class DistributionPool : ISerializable
 						return; // Not valid
 					// All cases here use the argument list when generating pools
 					break;
+
+				case "BOSSMODULE":
+				case "BOSS_MODULE":
+					FinalType = PoolType.BossModule;
+					break;
 			}
 			Type = FinalType ?? PoolType.Invalid;
 		}
@@ -299,6 +309,18 @@ public sealed class DistributionPool : ISerializable
 					if (!reverseLookup.ContainsKey(Module))
 						throw new InvalidOperationException($"This distribution contains a fixed pool, and at least one of the modules in that pool ({Module}) is not enabled.");
 					return reverseLookup[Module];
+				}).ToList();
+				break;
+
+			case PoolType.BossModule:
+				ModulePool = AllModules.Where(x =>
+				{
+					if (x.IsNeedy)
+						return false;
+
+					ModuleInformation info = ComponentSolverFactory.GetModuleInfo(GetTwitchPlaysID(x), false);
+					return info.announceModule;
+
 				}).ToList();
 				break;
 

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -336,6 +336,83 @@ public class TwitchPlaySettingsData
 			}
 		}},
 
+		// Strict Difficulty distributions
+		{ "easy", new ModuleDistributions {
+			DisplayName = "Strict Easy",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.5f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.4f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.1f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+			}
+		}},
+		{ "medium", new ModuleDistributions {
+			DisplayName = "Strict Medium",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.4f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.35f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.2f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.05f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+			}
+		}},
+		{ "hard", new ModuleDistributions {
+			DisplayName = "Strict Hard",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.3f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.35f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.25f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.1f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+			}
+		}},
+		{ "expert", new ModuleDistributions {
+			DisplayName = "Strict Expert",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.2f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.3f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.3f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.2f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+			}
+		}},
+		{ "easy+boss", new ModuleDistributions {
+			DisplayName = "Strict Easy",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.5f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.4f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.1f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.0f, "BossModule", /* Reward */ 0, /* Time */ 300),
+			}
+		}},
+		{ "medium+boss", new ModuleDistributions {
+			DisplayName = "Strict Medium",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.4f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.35f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.2f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.05f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.0f, "BossModule", /* Reward */ 0, /* Time */ 300),
+			}
+		}},
+		{ "hard+boss", new ModuleDistributions {
+			DisplayName = "Strict Hard",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.3f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.35f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.25f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.1f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.0f, "BossModule", /* Reward */ 0, /* Time */ 300),
+			}
+		}},
+		{ "expert+boss", new ModuleDistributions {
+			DisplayName = "Strict Expert",
+			Pools = new List<DistributionPool> {
+				new DistributionPool(0.2f, "Score: <= 8", /* Reward */ 3, /* Time */ 90),
+				new DistributionPool(0.3f, "Score: >= 9, <= 15"),
+				new DistributionPool(0.3f, "Score: >= 16, <= 24", /* Reward */ 8, /* Time */ 90),
+				new DistributionPool(0.2f, "Score: >= 25",        /* Reward */ 10, /* Time */ 240),
+				new DistributionPool(0.0f, "BossModule", /* Reward */ 0, /* Time */ 300),
+			}
+		}},
+
+
 		// Variety distributions
 		{ "variety", new ModuleDistributions {
 			DisplayName = "Variety Mix",
@@ -362,8 +439,8 @@ public class TwitchPlaySettingsData
 				new DistributionPool(0.09f, "Score: >= 20",        /* Reward */ 10, /* Time */ 240),
 
 				new DistributionPool(0.0865f, "AllSolvable"),
-				new DistributionPool(0.0435f, "DisabledBy: NoBossModules", /* Reward */ 0, /* Time */ 300),
-				new DistributionPool(0.0f,    "DisabledBy: NoBossModules", /* Reward */ 0, /* Time */ 300),
+				new DistributionPool(0.0435f, "BossModule", /* Reward */ 0, /* Time */ 300),
+				new DistributionPool(0.0f,    "BossModule", /* Reward */ 0, /* Time */ 300),
 			},
 			MinModules = 2
 		}}


### PR DESCRIPTION
This is the start of the suggested improvements to TP bomb generation, as discussed in the TP server. 

New distributions are added, which force a spread of difficulty across a bomb, as well as an optional forced boss. 

Additional possible features (for the future, *cough* @eXish *cough*): 
1. Bomb spread including a set % of older modules, as a pool within these distributions. 
2. Setting a specific # of bosses (or "Complex Modules / CM's" as I have called them), instead of the pool name including the # of bosses. 