### PR TITLE
Add Kuro as a priority solve mod

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -754,7 +754,7 @@ static class GameCommands
 
 		var modules = TwitchGame.Instance.Modules
 			.Where(x => GameRoom.Instance.IsCurrentBomb(x.BombID))
-			.OrderByDescending(module => module.Solver.ModInfo.moduleID.EqualsAny("cookieJars", "organizationModule", "forgetMeLater", "encryptedHangman", "SecurityCouncil", "GSAccessCodes"));
+			.OrderByDescending(module => module.Solver.ModInfo.moduleID.EqualsAny("cookieJars", "organizationModule", "forgetMeLater", "encryptedHangman", "SecurityCouncil", "GSAccessCodes", "Kuro"));
 		foreach (var module in modules)
 			if (!module.Solved)
 				module.SolveSilently();


### PR DESCRIPTION
Kuro is an upcoming mod that has the possibility to strike if another mod is solved before doing a certain interaction. Adding it to the list should solve this problem.