### PR TITLE
Two new features and a bugfix

### DIFF
--- a/Assets/Plugins/Managed/documentation.xml
+++ b/Assets/Plugins/Managed/documentation.xml
@@ -524,7 +524,7 @@
             <syntax>ttks\nttksleft\nttksright\ninfozen\nqhelp</syntax>
             <summary>These commands send a predefined message to chat. Streamers can choose their own messages but the ones mentioned here are included by default.</summary>
         </member>
-        <member name="M:GameCommands.Mission(System.String,System.String,System.Boolean)">
+        <member name="M:GameCommands.Mission(System.String,System.Boolean)">
             <name>Show Mission Name</name>
             <syntax>status\nmission</syntax>
             <summary>View currently running mission name, if any.</summary>

--- a/Assets/Plugins/Managed/documentation.xml
+++ b/Assets/Plugins/Managed/documentation.xml
@@ -379,6 +379,12 @@
             <summary>Rotates the bomb to show the edgework. (edge) is which edge of the bomb will be shown, ex: top or top left. Using 45 will rotate the bomb in 45 degree increments.</summary>
             <restriction>ElevatorDisallowed</restriction>
         </member>
+        <member name="M:GameCommands.EdgeworkFor(System.String,System.String,System.Boolean)">
+            <name>Edgework for a module</name>
+            <syntax>edgework (module-id)\nedgework 1</syntax>
+            <summary>In a game with multiple bombs, echoes to chat the edgework on the bomb that contains the specified module.</summary>
+            <restriction>ElevatorDisallowed</restriction>
+        </member>
         <member name="M:GameCommands.CameraWall(System.String,System.String)">
             <name>Camera Wall</name>
             <syntax>camerawall [mode]</syntax>

--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -610,7 +610,7 @@ static class GameCommands
 		DeleteCallInformation(true);
 		if (TwitchGame.Instance.Bombs.Any(x => x.BackdoorHandleHack))
 			IRCConnection.SendMessage("Hack detected, waiting until the hack is over to execute this command.");
-		TwitchGame.Instance.StartCoroutine(WaitForCall(new List<IRCMessage>(){ TwitchGame.Instance.callSend.Message }));
+		TwitchGame.Instance.StartCoroutine(WaitForCall(new List<IRCMessage>() { TwitchGame.Instance.callSend.Message }));
 	}
 
 	/// <name>Call All</name>
@@ -902,7 +902,7 @@ static class GameCommands
 	/// <syntax>status\nmission</syntax>
 	/// <summary>View currently running mission name, if any.</summary>
 	[Command(@"(?:status|mission)")]
-	public static void Mission(string cmd, string user, bool isWhisper)
+	public static void Mission(string user, bool isWhisper)
 	{
 		if (GameplayState.MissionToLoad.EqualsAny(Assets.Scripts.Missions.FreeplayMissionGenerator.FREEPLAY_MISSION_ID, ModMission.CUSTOM_MISSION_ID))
 		{
@@ -971,7 +971,8 @@ static class GameCommands
 		calledCommands.AddRange(cmdsToExecute);
 		if (alreadyExecuting) yield break;
 
-		if (TwitchGame.Instance.Bombs.Any(x => x.BackdoorHandleHack)) {
+		if (TwitchGame.Instance.Bombs.Any(x => x.BackdoorHandleHack))
+		{
 			yield return new WaitUntil(() => TwitchGame.Instance.Bombs.All(x => !x.BackdoorHandleHack));
 			IRCConnection.SendMessage("The hack is over, executing all commands held up due to the hack.");
 		}

--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -477,6 +477,20 @@ static class GameCommands
 			return null;
 		}
 	}
+	/// <name>Edgework for a module</name>
+	/// <syntax>edgework (module-id)\nedgework 1</syntax>
+	/// <summary>In a game with multiple bombs, echoes to chat the edgework on the bomb that contains the specified module.</summary>
+	/// <restriction>ElevatorDisallowed</restriction>
+	[Command(@"(?:edgeworkfor|ewfor)\s+(.+)"), ElevatorDisallowed]
+	public static IEnumerator EdgeworkFor([Group(1)] string moduleId, string user, bool isWhisper)
+	{
+		var module = TwitchGame.Instance.Modules.FirstOrDefault(m => m.Code == moduleId);
+		if (module == null)
+			IRCConnection.SendMessage($"@{user}, no such module.", user, !isWhisper);
+		else
+			IRCConnection.SendMessage(TwitchPlaySettings.data.BombEdgeworkFor, user, !isWhisper, module.HeaderText, module.Code, module.Bomb.EdgeworkText.text, module.Bomb.BombID);
+		return null;
+	}
 
 	/// <name>Camera Wall</name>
 	/// <syntax>camerawall [mode]</syntax>

--- a/TwitchPlaysAssembly/Src/GameplayRooms/Factory.cs
+++ b/TwitchPlaysAssembly/Src/GameplayRooms/Factory.cs
@@ -160,12 +160,15 @@ public sealed class Factory : GameRoom
 			});
 			if (!TwitchGame.BombActive) yield break;
 
+			// In between sequence bombs, award players who maintained modules on the previous bomb.
+			TwitchGame.Instance.AwardMaintainedModules();
+
 			IRCConnection.SendMessage(TwitchGame.Instance.GetBombResult(false));
 			TwitchPlaySettings.SetRetryReward();
 
 			foreach (TwitchModule handle in TwitchGame.Instance.Modules)
 			{
-				//If the camera is still attached to the bomb component when the bomb gets destroyed, then THAT camera is destroyed as wel.
+				//If the camera is still attached to the bomb component when the bomb gets destroyed, then THAT camera is destroyed as well.
 				TwitchGame.ModuleCameras.UnviewModule(handle);
 			}
 

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -563,6 +563,7 @@ public class TwitchPlaySettingsData
 	public string BombHelp = "The Bomb: !bomb hold [pick up] | !bomb drop | !bomb turn [turn to the other side] | !bomb edgework [show the widgets on the sides] | !bomb top [show one side; sides are Top/Bottom/Left/Right | !bomb time [time remaining] | !bomb timestamp [bomb start time]";
 	public string BlankBombEdgework = "Not set, use !edgework <edgework> to set!\nUse !bomb edgework or !bomb edgework 45 to view the bomb edges.";
 	public string BombEdgework = "Edgework: {0}";
+	public string BombEdgeworkFor = "Edgework for {0} ({1}): {2} (bomb {3})";
 	public string BombTimeRemaining = "panicBasket [{0}] out of [{1}].";
 	public string BombTimeStamp = "The Date/Time this bomb started is {0:F}";
 	public string BombDetonateCommand = "panicBasket This bomb's gonna blow!";

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -523,7 +523,7 @@ public class TwitchPlaySettingsData
 	public string TakeInProgress = "@{0}, there is already a takeover attempt for module {1} ({2}) in progress.";
 	public string ModuleIsMine = "{0} confirms he/she is still working on {1} ({2}).";
 	public string TooManyClaimed = "ItsBoshyTime {0}, you may only have {1} claimed modules. The claim has been queued.";
-	public string TooManyClaimedOverride = "ItsBoshyTime {0}, you may only have {1} claimed modules, unless all of your claimed modules are in the command queue. The claim has been queued.";
+	public string TooManyClaimedQueue = "ItsBoshyTime {0}, you may only have {1} claimed modules, and {2} ({3}) is not in the command queue. The claim has been queued.";
 	public string NoUnclaimed = "{0}, there are no more unclaimed modules.";
 	public string ModulePlayer = "Module {0} ({2}) was claimed by {1}.";
 	public string AlreadyClaimed = "@{2}, module {0} ({3}) is currently claimed by {1}. If you think they have abandoned it, type !{0} take to free it up.";

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -519,13 +519,22 @@ public class TwitchModule : MonoBehaviour
 		}
 
 		// Would violate the claim limit ⇒ queue
+		TwitchModule unclaimedModule = null;
 		if (TwitchGame.Instance.Modules.Count(md => md.PlayerName != null && md.PlayerName.EqualsIgnoreCase(userNickName) && !md.Solved) >= TwitchPlaySettings.data.ModuleClaimLimit
-			&& (TwitchGame.Instance.Modules.Any(module => module.PlayerName != null && module.PlayerName.EqualsIgnoreCase(userNickName) && !module.Solved && TwitchGame.Instance.CommandQueue.All(item => !item.Message.Text.StartsWith($"!{module.Code} ")) && !module.Solver.ModInfo.announceModule && !(module.BombComponent is ModNeedyComponent)) || !TwitchPlaySettings.data.QueuedClaimOverride)
-			&& (!UserAccess.HasAccess(userNickName, AccessLevel.SuperUser, true) || !TwitchPlaySettings.data.SuperStreamerIgnoreClaimLimit))
+			&& (!UserAccess.HasAccess(userNickName, AccessLevel.SuperUser, true) || !TwitchPlaySettings.data.SuperStreamerIgnoreClaimLimit)
+			&& (
+				!TwitchPlaySettings.data.QueuedClaimOverride ||
+				(unclaimedModule = TwitchGame.Instance.Modules.FirstOrDefault(module => module.PlayerName != null &&
+							module.PlayerName.EqualsIgnoreCase(userNickName) &&
+							!module.Solved &&
+							TwitchGame.Instance.CommandQueue.All(item => !item.Message.Text.StartsWith($"!{module.Code} ")) &&
+							!module.Solver.ModInfo.announceModule &&
+							!(module.BombComponent is ModNeedyComponent))) != null))
 		{
 			AddToClaimQueue(userNickName, viewRequested, viewPinRequested);
-			return new ClaimResult(false, string.Format(TwitchPlaySettings.data.QueuedClaimOverride ? TwitchPlaySettings.data.TooManyClaimedOverride : TwitchPlaySettings.data.TooManyClaimed,
-				userNickName, TwitchPlaySettings.data.ModuleClaimLimit));
+			return new ClaimResult(false, TwitchPlaySettings.data.QueuedClaimOverride
+				? string.Format(TwitchPlaySettings.data.TooManyClaimedQueue, userNickName, TwitchPlaySettings.data.ModuleClaimLimit, unclaimedModule.HeaderText, unclaimedModule.Code)
+				: string.Format(TwitchPlaySettings.data.TooManyClaimed, userNickName, TwitchPlaySettings.data.ModuleClaimLimit));
 		}
 
 		// Check the claim cooldown at the start of the bomb

--- a/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
+++ b/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
@@ -7,10 +7,7 @@
     <LangVersion>7.3</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Deterministic>false</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <Configurations>Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/TwitchPlaysAssembly/TwitchPlaysAssembly.sln
+++ b/TwitchPlaysAssembly/TwitchPlaysAssembly.sln
@@ -1,18 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29519.87
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchPlaysAssembly", "TwitchPlaysAssembly.csproj", "{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchPlaysAssembly", "TwitchPlaysAssembly.csproj", "{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B2DBE282-D779-4B15-BDC9-C747EA7EAF72}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -524,7 +524,7 @@
             <syntax>ttks\nttksleft\nttksright\ninfozen\nqhelp</syntax>
             <summary>These commands send a predefined message to chat. Streamers can choose their own messages but the ones mentioned here are included by default.</summary>
         </member>
-        <member name="M:GameCommands.Mission(System.String,System.String,System.Boolean)">
+        <member name="M:GameCommands.Mission(System.String,System.Boolean)">
             <name>Show Mission Name</name>
             <syntax>status\nmission</syntax>
             <summary>View currently running mission name, if any.</summary>

--- a/docs/documentation.xml
+++ b/docs/documentation.xml
@@ -379,6 +379,12 @@
             <summary>Rotates the bomb to show the edgework. (edge) is which edge of the bomb will be shown, ex: top or top left. Using 45 will rotate the bomb in 45 degree increments.</summary>
             <restriction>ElevatorDisallowed</restriction>
         </member>
+        <member name="M:GameCommands.EdgeworkFor(System.String,System.String,System.Boolean)">
+            <name>Edgework for a module</name>
+            <syntax>edgework (module-id)\nedgework 1</syntax>
+            <summary>In a game with multiple bombs, echoes to chat the edgework on the bomb that contains the specified module.</summary>
+            <restriction>ElevatorDisallowed</restriction>
+        </member>
         <member name="M:GameCommands.CameraWall(System.String,System.String)">
             <name>Camera Wall</name>
             <syntax>camerawall [mode]</syntax>


### PR DESCRIPTION
# ①

Change the message:

> you may only have {1} claimed modules, unless all of your claimed modules are in the command queue

to:

> you may only have {1} claimed modules, and {2} ({3}) is not in the command queue

In other words, tell the user which of their claimed modules is not in the queue.

# ②

Create a new command `!edgeworkfor`/`!ewfor` that allows a player in a game with multiple bombs to determine which edgework is the correct one for a specific module.

# ③

TP discards all scores for needies (etc.) for all but the last bomb in a Factory sequence mission. This change fixes that by awarding points between bombs as well.