### PR TITLE
Fix exceptions from recent repo additions + shim fixes

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/BorderedKeysShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/BorderedKeysShim.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
+[ModuleID("borderedKeys")]
 internal class BorderedKeysShim : ReflectionComponentSolverShim
 {
 	private readonly KMSelectable display;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonServesShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/Misc/SimonServesShim.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+[ModuleID("simonServes")]
 internal class SimonServesShim : ComponentSolverShim
 {
 	private static readonly Type ComponentType = ReflectionHelper.FindType("simonServesScript");


### PR DESCRIPTION
The repo recently received new JSON entries for appendixes (Appendix FLASH for example). While widgets and holdables have a ModuleID field these do not, causing TP to throw exceptions as it assumes every entry on the repo has a ModuleID field.

Also fixed the Bordered Keys and Simon Serves shims not working due to missing the ModuleID.